### PR TITLE
Go back to sprat Bluetooth drivers stack

### DIFF
--- a/Documentation/arm/msm/msm_ipc_logging.txt
+++ b/Documentation/arm/msm/msm_ipc_logging.txt
@@ -149,7 +149,6 @@ Kernel-Space Interface APIs
  *
  * @max_num_pages: Number of pages of logging space required (max. 10)
  * @mod_name     : Name of the directory entry under DEBUGFS
- * @user_version : Version number of user-defined message formats
  *
  * returns reference to context on success, NULL on failure
  */

--- a/Documentation/devicetree/bindings/tty/serial/msm_serial_hs.txt
+++ b/Documentation/devicetree/bindings/tty/serial/msm_serial_hs.txt
@@ -64,9 +64,6 @@ for uart.
 receiving interrupt with UART RX GPIO IRQ line (i.e. above wakeup_irq property),
 HSUART driver injects provided character with property rx_to_inject.
 - qcom, rx-char-to-inject : The character to be inserted on wakeup.
-- qcom, no-suspend-delay : This decides system to go to suspend immediately
-or not
-
 - Refer to "Documentation/devicetree/bindings/arm/msm/msm_bus.txt" for
 below optional properties:
     - qcom,msm_bus,name

--- a/arch/arm/mach-msm/bam_dmux.c
+++ b/arch/arm/mach-msm/bam_dmux.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2013, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -2630,8 +2630,8 @@ static int __init bam_dmux_init(void)
 		pr_err("%s: Failed to create device file(%s)!\n",
 			__func__, dev_attr_waketime.attr.name);
 #endif
-	bam_ipc_log_txt = ipc_log_context_create(BAM_IPC_LOG_PAGES, "bam_dmux",
-			0);
+
+	bam_ipc_log_txt = ipc_log_context_create(BAM_IPC_LOG_PAGES, "bam_dmux");
 	if (!bam_ipc_log_txt) {
 		pr_err("%s : unable to create IPC Logging Context", __func__);
 	}

--- a/arch/arm/mach-msm/include/mach/msm_serial_hs.h
+++ b/arch/arm/mach-msm/include/mach/msm_serial_hs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008 Google, Inc.
- * Copyright (C) 2010-2014, The Linux Foundation. All rights reserved.
+ * Copyright (C) 2010-2013, The Linux Foundation. All rights reserved.
  * Author: Nick Pelly <npelly@google.com>
  *
  * This software is licensed under the terms of the GNU General Public
@@ -32,8 +32,6 @@
  * @uart_rfr_gpio: GPIO number for UART RFR Line.
  * @bam_tx_ep_pipe_index : BAM TX Endpoint Pipe Index for HSUART
  * @bam_tx_ep_pipe_index : BAM RX Endpoint Pipe Index for HSUART
- * @no_suspend_delay : Flag used to make system go to suspend
- * immediately or not
  */
 struct msm_serial_hs_platform_data {
 	int wakeup_irq;  /* wakeup irq */
@@ -48,7 +46,6 @@ struct msm_serial_hs_platform_data {
 	int uart_rfr_gpio;
 	unsigned bam_tx_ep_pipe_index;
 	unsigned bam_rx_ep_pipe_index;
-	bool no_suspend_delay;
 };
 
 unsigned int msm_hs_tx_empty(struct uart_port *uport);
@@ -58,5 +55,6 @@ struct uart_port *msm_hs_get_uart_port(int port_index);
 void msm_hs_set_mctrl(struct uart_port *uport,
 				    unsigned int mctrl);
 
+struct uart_port * msm_hs_get_port_by_id(int num);
 int msm_hs_get_clock_state(struct uart_port *uport);
 #endif

--- a/arch/arm/mach-msm/ipc_logging.c
+++ b/arch/arm/mach-msm/ipc_logging.c
@@ -552,18 +552,8 @@ static void *get_deserialization_func(struct ipc_log_context *ilctxt,
 	return NULL;
 }
 
-/**
- * ipc_log_context_create: Create a debug log context
- *                         Should not be called from atomic context
- *
- * @max_num_pages: Number of pages of logging space required (max. 10)
- * @mod_name     : Name of the directory entry under DEBUGFS
- * @user_version : Version number of user-defined message formats
- *
- * returns context id on success, NULL on failure
- */
 void *ipc_log_context_create(int max_num_pages,
-			     const char *mod_name, uint16_t user_version)
+			     const char *mod_name)
 {
 	struct ipc_log_context *ctxt;
 	struct ipc_log_page *pg = NULL;
@@ -597,7 +587,6 @@ void *ipc_log_context_create(int max_num_pages,
 		list_add_tail(&pg->hdr.list, &ctxt->page_list);
 		spin_unlock_irqrestore(&ctxt->ipc_log_context_lock, flags);
 	}
-	ctxt->user_version = user_version;
 	ctxt->first_page = get_first_page(ctxt);
 	ctxt->last_page = pg;
 	ctxt->write_page = ctxt->first_page;

--- a/arch/arm/mach-msm/ipc_logging.h
+++ b/arch/arm/mach-msm/ipc_logging.h
@@ -30,26 +30,7 @@ struct ipc_log_page {
 	char data[PAGE_SIZE - sizeof(struct ipc_log_page_header)];
 };
 
-/**
- * struct ipc_log_context - main logging context
- *
- * @user_version:  Version number for user-defined messages
- * @list:  List of log contexts (struct ipc_log_context)
- * @page_list:  List of log pages (struct ipc_log_page)
- * @first_page:  First page in list of logging pages
- * @last_page:  Last page in list of logging pages
- * @write_page:  Current write page
- * @read_page:  Current read page (for internal reads)
- * @write_avail:  Number of bytes available to write in all pages
- * @dent:  Debugfs node for run-time log extraction
- * @dfunc_info_list:  List of deserialization functions
- * @ipc_log_context_lock:  Lock for entire structure
- * @read_avail:  Completed when new data is added to the log
- */
 struct ipc_log_context {
-	uint16_t user_version;
-
-	/* add local data structures after this point */
 	struct list_head list;
 	struct list_head page_list;
 	struct ipc_log_page *first_page;

--- a/arch/arm/mach-msm/ipc_router.c
+++ b/arch/arm/mach-msm/ipc_router.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2013, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -3328,7 +3328,7 @@ static int __init msm_ipc_router_init(void)
 
 	msm_ipc_router_debug_mask |= SMEM_LOG;
 	ipc_rtr_log_ctxt = ipc_log_context_create(IPC_RTR_LOG_PAGES,
-						  "ipc_router", 0);
+						  "ipc_router");
 	if (!ipc_rtr_log_ctxt)
 		pr_err("%s: Unable to create IPC logging for IPC RTR",
 			__func__);

--- a/arch/arm/mach-msm/ipc_socket.c
+++ b/arch/arm/mach-msm/ipc_socket.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2011-2013, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -626,13 +626,13 @@ void msm_ipc_router_ipc_log_init(void)
 {
 	ipc_req_resp_log_txt =
 		ipc_log_context_create(REQ_RESP_IPC_LOG_PAGES,
-			"ipc_rtr_req_resp", 0);
+			"ipc_rtr_req_resp");
 	if (!ipc_req_resp_log_txt) {
 		pr_err("%s: Unable to create IPC logging for Req/Resp",
 			__func__);
 	}
 	ipc_ind_log_txt =
-		ipc_log_context_create(IND_IPC_LOG_PAGES, "ipc_rtr_ind", 0);
+		ipc_log_context_create(IND_IPC_LOG_PAGES, "ipc_rtr_ind");
 	if (!ipc_ind_log_txt) {
 		pr_err("%s: Unable to create IPC logging for Indications",
 			__func__);

--- a/arch/arm/mach-msm/smd.c
+++ b/arch/arm/mach-msm/smd.c
@@ -1,7 +1,7 @@
 /* arch/arm/mach-msm/smd.c
  *
  * Copyright (C) 2007 Google, Inc.
- * Copyright (c) 2008-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2008-2013, The Linux Foundation. All rights reserved.
  * Author: Brian Swetland <swetland@google.com>
  *
  * This software is licensed under the terms of the GNU General Public
@@ -3340,13 +3340,13 @@ int __init msm_smd_init(void)
 	if (registered)
 		return 0;
 
-	smd_log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smd", 0);
+	smd_log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smd");
 	if (!smd_log_ctx) {
 		pr_err("%s: unable to create SMD logging context\n", __func__);
 		msm_smd_debug_mask = 0;
 	}
 
-	smsm_log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smsm", 0);
+	smsm_log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smsm");
 	if (!smsm_log_ctx) {
 		pr_err("%s: unable to create SMSM logging context\n", __func__);
 		msm_smd_debug_mask = 0;

--- a/arch/arm/mach-msm/smd_pkt.c
+++ b/arch/arm/mach-msm/smd_pkt.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2008-2013, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -1123,7 +1123,7 @@ static int __init smd_pkt_init(void)
 	INIT_DELAYED_WORK(&loopback_work, loopback_probe_worker);
 
 	smd_pkt_ilctxt = ipc_log_context_create(SMD_PKT_IPC_LOG_PAGE_CNT,
-						"smd_pkt", 0);
+						"smd_pkt");
 
 	D_STATUS("SMD Packet Port Driver Initialized.\n");
 	return 0;

--- a/arch/arm/mach-msm/smd_tty.c
+++ b/arch/arm/mach-msm/smd_tty.c
@@ -1,7 +1,7 @@
 /* arch/arm/mach-msm/smd_tty.c
  *
  * Copyright (C) 2007 Google, Inc.
- * Copyright (c) 2009-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2009-2013, The Linux Foundation. All rights reserved.
  * Author: Brian Swetland <swetland@google.com>
  *
  * This software is licensed under the terms of the GNU General Public
@@ -705,7 +705,7 @@ static int smd_tty_dummy_probe(struct platform_device *pdev)
 static void smd_tty_log_init(void)
 {
 	smd_tty_log_ctx = ipc_log_context_create(SMD_TTY_LOG_PAGES,
-						"smd_tty", 0);
+						"smd_tty");
 	if (!smd_tty_log_ctx)
 		pr_err("%s: Unable to create IPC log", __func__);
 }

--- a/arch/arm/mach-msm/smem.c
+++ b/arch/arm/mach-msm/smem.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2014, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -1370,7 +1370,7 @@ int __init msm_smem_init(void)
 
 	registered = true;
 
-	smem_ipc_log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smem", 0);
+	smem_ipc_log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smem");
 	if (!smem_ipc_log_ctx) {
 		pr_err("%s: unable to create logging context\n", __func__);
 		msm_smem_debug_mask = 0;

--- a/arch/arm/mach-msm/smp2p.c
+++ b/arch/arm/mach-msm/smp2p.c
@@ -1,6 +1,6 @@
 /* arch/arm/mach-msm/smp2p.c
  *
- * Copyright (c) 2013-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -1829,7 +1829,7 @@ static int __init msm_smp2p_init(void)
 		in_list[i].smem_edge_in = NULL;
 	}
 
-	log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smp2p", 0);
+	log_ctx = ipc_log_context_create(NUM_LOG_PAGES, "smp2p");
 	if (!log_ctx)
 		SMP2P_ERR("%s: unable to create log context\n", __func__);
 

--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -32,6 +32,7 @@
 #include <linux/kernel.h>
 #include <linux/notifier.h>
 #include <linux/proc_fs.h>
+#include <linux/seq_file.h>
 #include <linux/spinlock.h>
 #include <linux/timer.h>
 #include <linux/uaccess.h>
@@ -53,16 +54,8 @@
 #include <net/bluetooth/hci_core.h> /* event notifications */
 #include "hci_uart.h"
 
-#include <linux/barcode_emul.h>
 
-
-#define BT_SLEEP_DBG
-#ifndef BT_SLEEP_DBG
-#define BT_DBG(fmt, arg...)
-#endif
-#undef  BT_DBG
 #undef BT_ERR
-#define BT_DBG(fmt, arg...) pr_err(fmt " [BT]\n", ##arg)
 #define BT_ERR(fmt, arg...) pr_err(fmt " [BT]\n", ##arg)
 
 /*
@@ -98,18 +91,17 @@ static void bluesleep_uart_awake_work(struct work_struct *work);
 
 /* work queue */
 DECLARE_DELAYED_WORK(sleep_workqueue, bluesleep_sleep_work);
-DECLARE_DELAYED_WORK(uart_awake_workqueue, bluesleep_uart_awake_work);
+DECLARE_DELAYED_WORK(uart_awake_wq, bluesleep_uart_awake_work);
 
 /* Macros for handling sleep work */
-#define bluesleep_rx_busy()     schedule_delayed_work(&sleep_workqueue, 0)
-#define bluesleep_tx_busy()     schedule_delayed_work(&sleep_workqueue, 0)
-#define bluesleep_rx_idle()     schedule_delayed_work(&sleep_workqueue, 0)
-#define bluesleep_tx_idle()     schedule_delayed_work(&sleep_workqueue, 0)
-#define bluesleep_uart_work()     schedule_delayed_work(&uart_awake_workqueue, 0)
+#define bluesleep_rx_busy() schedule_delayed_work(&sleep_workqueue, 0)
+#define bluesleep_tx_busy() schedule_delayed_work(&sleep_workqueue, 0)
+#define bluesleep_rx_idle() schedule_delayed_work(&sleep_workqueue, 0)
+#define bluesleep_tx_idle() schedule_delayed_work(&sleep_workqueue, 0)
+#define bluesleep_uart_work() schedule_delayed_work(&uart_awake_wq, 0)
 
-/* 5 second timeout */
-#define TX_TIMER_INTERVAL	5
-
+/* 0.5 second timeout */
+#define TX_TIMER_INTERVAL	1
 
 /* state variable names and bit positions */
 #define BT_PROTO	 0x01
@@ -145,7 +137,6 @@ struct mutex bluesleep_mutex;
 
 struct proc_dir_entry *bluetooth_dir, *sleep_dir;
 
-
 /* extern variable and functions */
 extern int poweroff_charging;
 
@@ -172,10 +163,12 @@ static void bluesleep_uart_awake_work(struct work_struct *work)
 
 	clk_state = bluesleep_get_uart_state();
 	if (clk_state == MSM_HS_CLK_OFF) {
-		BT_DBG("bluesleep_uart_awake_work : hsuart_power on");
-		msm_hs_request_clock_on(bsi->uport);
-		msm_hs_set_mctrl(bsi->uport, TIOCM_RTS);
-	}else if(clk_state == MSM_HS_CLK_REQUEST_OFF){
+		if(bt_enabled) {
+			BT_DBG("bluesleep_uart_awake_work : hsuart_power on");
+			msm_hs_request_clock_on(bsi->uport);
+			msm_hs_set_mctrl(bsi->uport, TIOCM_RTS);
+		}
+	} else if (clk_state == MSM_HS_CLK_REQUEST_OFF) {
 		bluesleep_uart_work();
 	}
 }
@@ -195,7 +188,7 @@ static void hsuart_power(int on)
 	}
 
 	if (on) {
-		if(test_bit(BT_TXDATA, &flags)) {
+		if (test_bit(BT_TXDATA, &flags)) {
 			BT_DBG("hsuart_power on");
 			msm_hs_request_clock_on(bsi->uport);
 			msm_hs_set_mctrl(bsi->uport, TIOCM_RTS);
@@ -203,7 +196,7 @@ static void hsuart_power(int on)
 		}
 
 		clk_state = bluesleep_get_uart_state();
-		if(clk_state == MSM_HS_CLK_REQUEST_OFF) {
+		if (clk_state == MSM_HS_CLK_REQUEST_OFF) {
 			BT_DBG("hsuart_power wait");
 			bluesleep_uart_work();
 		} else {
@@ -225,7 +218,7 @@ int bluesleep_can_sleep(void)
 {
 	/* check if WAKE_BT_GPIO and BT_WAKE_GPIO are both deasserted */
 	return (!gpio_get_value(bsi->host_wake) &&
-		(bsi->uport != NULL));
+				(bsi->uport != NULL));
 }
 
 void bluesleep_sleep_wakeup(void)
@@ -237,14 +230,13 @@ void bluesleep_sleep_wakeup(void)
 		wake_lock(&bsi->wake_lock);
 		/* Start the timer */
 		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
-		if (bsi->has_ext_wake == 1) {
+		if (bsi->has_ext_wake == 1)
 			gpio_set_value(bsi->ext_wake, 1);
-		}
+
 		set_bit(BT_EXT_WAKE, &flags);
 		clear_bit(BT_ASLEEP, &flags);
-	}
-	else {
-		BT_DBG("bluesleep_sleep_wakeup : already wake up, so start timer...");
+	} else {
+		BT_DBG("bluesleep_sleep_wakeup : already wake up");
 		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
 	}
 }
@@ -257,14 +249,13 @@ static void bluesleep_tx_data_wakeup(void)
 		wake_lock(&bsi->wake_lock);
 		/* Start the timer */
 		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
-		if (bsi->has_ext_wake == 1) {
+		if (bsi->has_ext_wake == 1)
 			gpio_set_value(bsi->ext_wake, 1);
-		}
+
 		set_bit(BT_EXT_WAKE, &flags);
 		clear_bit(BT_ASLEEP, &flags);
-	}
-	else {
-		BT_DBG("bluesleep_tx_data_wakeup : already wake up, so start timer...");
+	} else {
+		BT_DBG("bluesleep_tx_data_wakeup : already wake up");
 		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
 	}
 }
@@ -281,20 +272,6 @@ static void bluesleep_sleep_work(struct work_struct *work)
 	if (mutex_is_locked(&bluesleep_mutex))
 		BT_DBG("Wait for mutex unlock in bluesleep_sleep_work");
 
-	if (bsi->uport == NULL) {
-		BT_DBG("bluesleep_sleep_work - uport is null");
-		return;
-	}
-
-	if (bsi->uport->state == NULL) {
-		BT_DBG("bluesleep_sleep_work - bsi->uport->state is null");
-		return;
-	}
-
-	if (bsi->uport->state->port.tty == NULL) {
-		BT_DBG("bluesleep_sleep_work - bsi->uport->state->port.tty is null");
-		return;
-	}
 	mutex_lock(&bluesleep_mutex);
 
 	if (bluesleep_can_sleep()) {
@@ -307,9 +284,10 @@ static void bluesleep_sleep_work(struct work_struct *work)
 
 		if (msm_hs_tx_empty(bsi->uport)) {
 			if (test_bit(BT_TXDATA, &flags)) {
-				BT_DBG("TXDATA remained. Wait until timer expires.");
+				BT_DBG("Wait until timer expires.");
 
-				mod_timer(&tx_timer, jiffies + TX_TIMER_INTERVAL * HZ);
+				mod_timer(&tx_timer,
+					jiffies + TX_TIMER_INTERVAL * HZ);
 				mutex_unlock(&bluesleep_mutex);
 				return;
 			}
@@ -327,10 +305,10 @@ static void bluesleep_sleep_work(struct work_struct *work)
 
 			/*Deactivating UART */
 			/* UART clk is not turned off immediately. Release
-			 * wakelock after 500 ms.
-			 */
+			* wakelock after 500 ms.
+			*/
 			wake_lock_timeout(&bsi->wake_lock, HZ / 2);
-		} else {
+			} else {
 			BT_DBG("host can enter sleep but some tx remained.");
 
 			mod_timer(&tx_timer, jiffies + TX_TIMER_INTERVAL * HZ);
@@ -339,11 +317,11 @@ static void bluesleep_sleep_work(struct work_struct *work)
 		}
 	} else if (!test_bit(BT_EXT_WAKE, &flags)
 			&& !test_bit(BT_ASLEEP, &flags)) {
-		BT_DBG("host_wake high and BT_EXT_WAKE & BT_ASLEEP already freed.");
+		BT_DBG("host_wake high");
 		mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
-		if (bsi->has_ext_wake == 1) {
+		if (bsi->has_ext_wake == 1)
 			gpio_set_value(bsi->ext_wake, 1);
-		}
+
 		set_bit(BT_EXT_WAKE, &flags);
 	} else {
 		bluesleep_sleep_wakeup();
@@ -372,6 +350,11 @@ static void bluesleep_hostwake_task(unsigned long data)
  */
 static void bluesleep_outgoing_data(void)
 {
+	if (!bt_enabled) {
+		BT_ERR("bluesleep_outgoing_data(), BT is not enabled");
+		return;
+	}
+
 	if (mutex_is_locked(&bluesleep_mutex))
 		BT_DBG("Wait for mutex unlock in bluesleep_outgoing_data");
 
@@ -381,20 +364,19 @@ static void bluesleep_outgoing_data(void)
 
 	BT_DBG("bluesleep_outgoing_data.");
 
-	/* if the tx side is sleeping... */
 	if (!test_bit(BT_EXT_WAKE, &flags))
 		BT_DBG("BT_EXT_WAKE freed");
 
 	if (!test_bit(BT_ASLEEP, &flags))
 		BT_DBG("BT_ASLEEP freed");
 
-		/*
-		** Uart Clk should be enabled promptly
-		** before bluedroid write TX data.
-		*/
-		hsuart_power(1);
+	/*
+	** Uart Clk should be enabled promptly
+	** before bluedroid write TX data.
+	*/
+	hsuart_power(1);
 
-		bluesleep_tx_data_wakeup();
+	bluesleep_tx_data_wakeup();
 
 	mutex_unlock(&bluesleep_mutex);
 }
@@ -406,17 +388,16 @@ static void bluesleep_start(void)
 {
 	int retval;
 
-	if (test_bit(BT_PROTO, &flags)) {
+	if (test_bit(BT_PROTO, &flags))
 		return;
-	}
 
 	/* start the timer */
 	mod_timer(&tx_timer, jiffies + (TX_TIMER_INTERVAL * HZ));
 
 	/* assert BT_WAKE */
-	if (bsi->has_ext_wake == 1) {
+	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 1);
-	}
+
 	set_bit(BT_EXT_WAKE, &flags);
 	retval = enable_irq_wake(bsi->host_wake_irq);
 	if (retval < 0) {
@@ -434,24 +415,24 @@ fail:
 
 static void bluesleep_abnormal_stop(void)
 {
-    BT_ERR("bluesleep_abnormal_stop");
+	BT_ERR("bluesleep_abnormal_stop");
 
-    if (!test_bit(BT_PROTO, &flags)) {
-        BT_ERR("(bluesleep_abnormal_stop) proto is not set. Failed to stop bluesleep");
-        bsi->uport = NULL;
-        return;
-    }
+	if (!test_bit(BT_PROTO, &flags)) {
+		BT_ERR("(bluesleep_abnormal_stop) proto is not set.");
+		bsi->uport = NULL;
+		return;
+	}
 
-    del_timer(&tx_timer);
-    clear_bit(BT_PROTO, &flags);
+	del_timer(&tx_timer);
+	clear_bit(BT_PROTO, &flags);
 
-    if (disable_irq_wake(bsi->host_wake_irq))
-        BT_ERR("Couldn't disable hostwake IRQ wakeup mode\n");
+	if (disable_irq_wake(bsi->host_wake_irq))
+		BT_ERR("Couldn't disable hostwake IRQ wakeup mode\n");
 
-    wake_lock_timeout(&bsi->wake_lock, HZ / 2);
+	wake_lock_timeout(&bsi->wake_lock, HZ / 2);
 
-    clear_bit(BT_TXDATA, &flags);
-    bsi->uport = NULL;
+	clear_bit(BT_TXDATA, &flags);
+	bsi->uport = NULL;
 }
 
 /**
@@ -460,14 +441,14 @@ static void bluesleep_abnormal_stop(void)
 static void bluesleep_stop(void)
 {
 	if (!test_bit(BT_PROTO, &flags)) {
-		BT_ERR("(bluesleep_stop_wq) proto is not set. Failed to stop bluesleep");
+		BT_ERR("(bluesleep_stop_wq) proto is not set.");
 		bsi->uport = NULL;
 		return;
 	}
 	/* assert BT_WAKE */
-	if (bsi->has_ext_wake == 1) {
+	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 1);
-	}
+
 	set_bit(BT_EXT_WAKE, &flags);
 	del_timer(&tx_timer);
 	clear_bit(BT_PROTO, &flags);
@@ -489,20 +470,23 @@ struct uart_port *bluesleep_get_uart_port(void)
 {
 	struct uart_port *uport = NULL;
 
-	uport = msm_hs_get_uart_port(0);
+	uport = msm_hs_get_port_by_id(0);
 
 	return uport;
 }
 
-static int bluesleep_read_proc_lpm(char *page, char **start, off_t offset,
-					int count, int *eof, void *data)
+static ssize_t bluesleep_read_proc_lpm
+				(struct file *file,
+				char __user *userbuf,
+				size_t bytes,
+				loff_t *off)
 {
-    *eof = 1;
-	return snprintf(page, count, "lpm: %u\n", bt_enabled?1:0 );
+	return 0;
 }
 
-static int bluesleep_write_proc_lpm(struct file *file, const char *buffer,
-					unsigned long count, void *data)
+static ssize_t bluesleep_write_proc_lpm
+				(struct file *file, const char __user *buffer,
+				size_t count, loff_t *pos)
 {
 	char b;
 
@@ -515,9 +499,8 @@ static int bluesleep_write_proc_lpm(struct file *file, const char *buffer,
 	if (b == '0') {
 		BT_ERR("(bluesleep_write_proc_lpm) Unreg HCI notifier.");
 		/* HCI_DEV_UNREG */
-		bluesleep_stop();
 		bt_enabled = false;
-		//bsi->uport = NULL;
+		bluesleep_stop();
 	} else if (b == '1') {
 		BT_ERR("(bluesleep_write_proc_lpm) Reg HCI notifier.");
 		/* HCI_DEV_REG */
@@ -528,25 +511,26 @@ static int bluesleep_write_proc_lpm(struct file *file, const char *buffer,
 			bluesleep_start();
 		}
 	} else if (b == '2') {
-        BT_ERR("(bluesleep_write_proc_lpm) don`t control ext_wake & uart clk");
-		if(bt_enabled) {
+		BT_ERR("don`t control ext_wake & uart clk");
+		if (bt_enabled) {
 			bt_enabled = false;
-            bluesleep_abnormal_stop();
-        }
+			bluesleep_abnormal_stop();
+		}
 	}
 
 	return count;
 }
 
-static int bluesleep_read_proc_btwrite(char *page, char **start, off_t offset,
-					int count, int *eof, void *data)
+static ssize_t bluesleep_read_proc_btwrite
+				(struct file *file, char __user *userbuf,
+				size_t bytes, loff_t *off)
 {
-	*eof = 1;
-	return snprintf(page, count, "unsupported to read\n");
+	return 0;
 }
 
-static int bluesleep_write_proc_btwrite(struct file *file, const char *buffer,
-					unsigned long count, void *data)
+static ssize_t bluesleep_write_proc_btwrite
+				(struct file *file, const char __user *buffer,
+				size_t count, loff_t *pos)
 {
 	char b;
 
@@ -608,12 +592,11 @@ static irqreturn_t bluesleep_hostwake_isr(int irq, void *dev_id)
  * @param data Not used.
  * @return The number of bytes written.
  */
-static int bluepower_read_proc_btwake(char *page, char **start, off_t offset,
-					int count, int *eof, void *data)
+static ssize_t bluepower_read_proc_btwake
+				(struct file *file, char __user *userbuf,
+				size_t bytes, loff_t *off)
 {
-	*eof = 1;
-	return snprintf(page, count, "btwake:%u\n", \
-				test_bit(BT_EXT_WAKE, &flags));
+	return 0;
 }
 
 /**
@@ -625,8 +608,9 @@ static int bluepower_read_proc_btwake(char *page, char **start, off_t offset,
  * @return On success, the number of bytes written. On error, -1, and
  * <code>errno</code> is set appropriately.
  */
-static int bluepower_write_proc_btwake(struct file *file, const char *buffer,
-					unsigned long count, void *data)
+static ssize_t bluepower_write_proc_btwake
+				(struct file *file, const char __user *buffer,
+				size_t count, loff_t *pos)
 {
 	char *buf;
 
@@ -642,14 +626,14 @@ static int bluepower_write_proc_btwake(struct file *file, const char *buffer,
 		return -EFAULT;
 	}
 	if (buf[0] == '0') {
-		if (bsi->has_ext_wake == 1) {
+		if (bsi->has_ext_wake == 1)
 			gpio_set_value(bsi->ext_wake, 0);
-		}
+
 		clear_bit(BT_EXT_WAKE, &flags);
 	} else if (buf[0] == '1') {
-		if (bsi->has_ext_wake == 1) {
+		if (bsi->has_ext_wake == 1)
 			gpio_set_value(bsi->ext_wake, 1);
-		}
+
 		set_bit(BT_EXT_WAKE, &flags);
 	} else {
 		kfree(buf);
@@ -672,12 +656,11 @@ static int bluepower_write_proc_btwake(struct file *file, const char *buffer,
  * @param data Not used.
  * @return The number of bytes written.
  */
-static int bluepower_read_proc_hostwake(char *page, char **start, off_t offset,
-					int count, int *eof, void *data)
+static ssize_t bluepower_read_proc_hostwake
+				(struct file *file, char __user *userbuf,
+				size_t bytes, loff_t *off)
 {
-	*eof = 1;
-	return snprintf(page, count, "hostwake: %u\n", \
-				gpio_get_value(bsi->host_wake));
+	return 0;
 }
 
 
@@ -693,14 +676,11 @@ static int bluepower_read_proc_hostwake(char *page, char **start, off_t offset,
  * @param data Not used.
  * @return The number of bytes written.
  */
-static int bluesleep_read_proc_asleep(char *page, char **start, off_t offset,
-					int count, int *eof, void *data)
+static ssize_t bluesleep_read_proc_asleep
+				(struct file *file, char __user *userbuf,
+				size_t bytes, loff_t *off)
 {
-	unsigned int asleep;
-
-	asleep = test_bit(BT_ASLEEP, &flags) ? 1 : 0;
-	*eof = 1;
-	return snprintf(page, count, "asleep: %u\n", asleep);
+	return 0;
 }
 
 /**
@@ -715,14 +695,11 @@ static int bluesleep_read_proc_asleep(char *page, char **start, off_t offset,
  * @param data Not used.
  * @return The number of bytes written.
  */
-static int bluesleep_read_proc_proto(char *page, char **start, off_t offset,
-					int count, int *eof, void *data)
+static ssize_t bluesleep_read_proc_proto
+				(struct file *file, char __user *userbuf,
+				size_t bytes, loff_t *off)
 {
-	unsigned int proto;
-
-	proto = test_bit(BT_PROTO, &flags) ? 1 : 0;
-	*eof = 1;
-	return snprintf(page, count, "proto: %u\n", proto);
+	return 0;
 }
 
 /**
@@ -734,8 +711,9 @@ static int bluesleep_read_proc_proto(char *page, char **start, off_t offset,
  * @return On success, the number of bytes written. On error, -1, and
  * <code>errno</code> is set appropriately.
  */
-static int bluesleep_write_proc_proto(struct file *file, const char *buffer,
-					unsigned long count, void *data)
+static ssize_t bluesleep_write_proc_proto
+				(struct file *file, const char __user *buffer,
+				size_t count, loff_t *pos)
 {
 	char proto;
 
@@ -764,11 +742,11 @@ static int bluesleep_probe(struct platform_device *pdev)
 	int ret;
 	struct resource *res;
 
-    BT_ERR("bluesleep probe\n");
+	BT_ERR("bluesleep probe\n");
 
 	bsi = kzalloc(sizeof(struct bluesleep_info), GFP_KERNEL);
 	if (!bsi) {
-        BT_ERR("failed to allocate memory to bsi\n");
+		BT_ERR("failed to allocate memory to bsi\n");
 		return -ENOMEM;
 	}
 
@@ -784,25 +762,23 @@ static int bluesleep_probe(struct platform_device *pdev)
 	bsi->host_wake = res->start;
 
 	ret = gpio_request(bsi->host_wake, "bt_host_wake");
-	if (ret)
-	{
+	if (ret) {
 		BT_ERR("bluesleep_probe gpio_request for host_wake is failed");
 		goto free_bsi;
 	}
 
 	/* configure host_wake as input */
-#if !defined(CONFIG_BT_BCM4354)
 	BT_ERR("configure input direction\n");
-	gpio_tlmm_config(GPIO_CFG(bsi->host_wake, 0, GPIO_CFG_INPUT,
-					GPIO_CFG_NO_PULL, GPIO_CFG_16MA), GPIO_CFG_ENABLE);
+	gpio_tlmm_config(
+			GPIO_CFG(bsi->host_wake, 0, GPIO_CFG_INPUT,
+			GPIO_CFG_NO_PULL, GPIO_CFG_16MA), GPIO_CFG_ENABLE);
 	ret = gpio_direction_input(bsi->host_wake);
 	if (ret < 0) {
-		BT_ERR("gpio-keys: failed to configure input direction for GPIO %d, error %d",
+		BT_ERR("failed to configure ID for GPIO %d, error %d",
 				bsi->host_wake, ret);
 		gpio_free(bsi->host_wake);
 		goto free_bsi;
 	}
-#endif
 	res = platform_get_resource_byname(pdev, IORESOURCE_IO,
 				"gpio_ext_wake");
 
@@ -815,16 +791,15 @@ static int bluesleep_probe(struct platform_device *pdev)
 		bsi->ext_wake = res->start;
 
 		ret = gpio_request(bsi->ext_wake, "bt_ext_wake");
-		if (ret)
-		{
-			BT_ERR("bluesleep_probe gpio_request for bt_ext_wake is failed");
+		if (ret) {
+			BT_ERR("gpio_request for bt_ext_wake is failed");
 			goto free_bt_host_wake;
 		}
 
 		/* configure ext_wake as output mode*/
 		ret = gpio_direction_output(bsi->ext_wake, 0);
 		if (ret < 0) {
-			BT_ERR("gpio-keys: failed to configure output direction for GPIO %d, error %d",
+			BT_ERR("failed to configure OD for GPIO %d, error %d",
 				  bsi->ext_wake, ret);
 			gpio_free(bsi->ext_wake);
 			goto free_bt_host_wake;
@@ -894,12 +869,11 @@ static int bluesleep_remove(struct platform_device *pdev)
 static int bluesleep_resume(struct platform_device *pdev)
 {
 	if (test_bit(BT_SUSPEND, &flags)) {
-#ifndef CONFIG_BT_BCM4354
 		if (!bt_enabled) {
-			gpio_tlmm_config(GPIO_CFG(bsi->host_wake, 0, GPIO_CFG_INPUT,
-						GPIO_CFG_NO_PULL, GPIO_CFG_16MA), GPIO_CFG_ENABLE);
+			gpio_tlmm_config(GPIO_CFG(bsi->host_wake, 0,
+				GPIO_CFG_INPUT, GPIO_CFG_NO_PULL,
+				GPIO_CFG_16MA), GPIO_CFG_ENABLE);
 		}
-#endif
 		if ((bsi->uport != NULL) &&
 			(gpio_get_value(bsi->host_wake) == bsi->irq_polarity)) {
 				BT_DBG("bluesleep resume form BT event...");
@@ -912,12 +886,11 @@ static int bluesleep_resume(struct platform_device *pdev)
 
 static int bluesleep_suspend(struct platform_device *pdev, pm_message_t state)
 {
-#ifndef CONFIG_BT_BCM4354
 	if (!bt_enabled) {
 		gpio_tlmm_config(GPIO_CFG(bsi->host_wake, 0, GPIO_CFG_INPUT,
-						GPIO_CFG_PULL_DOWN, GPIO_CFG_16MA), GPIO_CFG_ENABLE);
+					GPIO_CFG_NO_PULL, GPIO_CFG_16MA),
+					GPIO_CFG_ENABLE);
 	}
-#endif
 	set_bit(BT_SUSPEND, &flags);
 	return 0;
 }
@@ -932,6 +905,37 @@ static struct platform_driver bluesleep_driver = {
 		.owner = THIS_MODULE,
 	},
 };
+
+static const struct file_operations proc_fops_btwake = {
+	.owner = THIS_MODULE,
+	.read = bluepower_read_proc_btwake,
+	.write = bluepower_write_proc_btwake,
+};
+static const struct file_operations proc_fops_hostwake = {
+	.owner = THIS_MODULE,
+	.read = bluepower_read_proc_hostwake,
+};
+static const struct file_operations proc_fops_proto = {
+	.owner = THIS_MODULE,
+	.read = bluesleep_read_proc_proto,
+	.write = bluesleep_write_proc_proto,
+};
+static const struct file_operations proc_fops_asleep = {
+	.owner = THIS_MODULE,
+	.read = bluesleep_read_proc_asleep,
+};
+static const struct file_operations proc_fops_lpm = {
+	.owner = THIS_MODULE,
+	.read = bluesleep_read_proc_lpm,
+	.write = bluesleep_write_proc_lpm,
+};
+static const struct file_operations proc_fops_btwrite = {
+	.owner = THIS_MODULE,
+	.read = bluesleep_read_proc_btwrite,
+	.write = bluesleep_write_proc_btwrite,
+};
+
+
 /**
  * Initializes the module.
  * @return On success, 0. On error, -1, and <code>errno</code> is set
@@ -941,6 +945,7 @@ static int __init bluesleep_init(void)
 {
 	int retval;
 	struct proc_dir_entry *ent;
+
 
 	if (poweroff_charging == 1) {
 		BT_ERR("bluesleep exit : lpm %d\n", poweroff_charging);
@@ -956,10 +961,9 @@ static int __init bluesleep_init(void)
 	if (retval)
 		return retval;
 
-	if (bsi == NULL)
-	{
+	if (bsi == NULL) {
 		BT_ERR("bluesleep_init failed. bsi is NULL!!");
-		return -1;
+		return -ENOMEM;
 	}
 
 	bluetooth_dir = proc_mkdir("bluetooth", NULL);
@@ -975,60 +979,51 @@ static int __init bluesleep_init(void)
 	}
 
 	/* Creating read/write "btwake" entry */
-	ent = create_proc_entry("btwake", 0, sleep_dir);
+	ent = proc_create("btwake", 0, sleep_dir, &proc_fops_btwake);
 	if (ent == NULL) {
 		BT_ERR("Unable to create /proc/%s/btwake entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
-	ent->read_proc = bluepower_read_proc_btwake;
-	ent->write_proc = bluepower_write_proc_btwake;
 
 	/* read only proc entries */
-	if (create_proc_read_entry("hostwake", 0, sleep_dir,
-				bluepower_read_proc_hostwake, NULL) == NULL) {
+	if (proc_create("hostwake", 0, sleep_dir,
+			&proc_fops_hostwake) == NULL) {
 		BT_ERR("Unable to create /proc/%s/hostwake entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
 
 	/* read/write proc entries */
-	ent = create_proc_entry("proto", 0, sleep_dir);
+	ent = proc_create("proto", 0, sleep_dir, &proc_fops_proto);
 	if (ent == NULL) {
 		BT_ERR("Unable to create /proc/%s/proto entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
-	ent->read_proc = bluesleep_read_proc_proto;
-	ent->write_proc = bluesleep_write_proc_proto;
 
 	/* read only proc entries */
-	if (create_proc_read_entry("asleep", 0,
-			sleep_dir, bluesleep_read_proc_asleep, NULL) == NULL) {
+	if (proc_create("asleep", 0, sleep_dir, &proc_fops_asleep) == NULL) {
 		BT_ERR("Unable to create /proc/%s/asleep entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
 
 	/* read/write proc entries */
-	ent = create_proc_entry("lpm", 0, sleep_dir);
+	ent = proc_create("lpm", 0, sleep_dir, &proc_fops_lpm);
 	if (ent == NULL) {
 		BT_ERR("Unable to create /proc/%s/lpm entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
-	ent->read_proc = bluesleep_read_proc_lpm;
-	ent->write_proc = bluesleep_write_proc_lpm;
 
 	/* read/write proc entries */
-	ent = create_proc_entry("btwrite", 0, sleep_dir);
+	ent = proc_create("btwrite", 0, sleep_dir, &proc_fops_btwrite);
 	if (ent == NULL) {
 		BT_ERR("Unable to create /proc/%s/btwrite entry", PROC_DIR);
 		retval = -ENOMEM;
 		goto fail;
 	}
-	ent->read_proc = bluesleep_read_proc_btwrite;
-	ent->write_proc = bluesleep_write_proc_btwrite;
 
 	flags = 0; /* clear all status bits */
 
@@ -1043,14 +1038,6 @@ static int __init bluesleep_init(void)
 	/* initialize host wake tasklet */
 	tasklet_init(&hostwake_task, bluesleep_hostwake_task, 0);
 
-	/* assert bt wake */
-	/* block code for FPGA to be set-up
-	if (bsi->has_ext_wake == 1) {
-		ret = ice_gpiox_set(bsi->ext_wake, 1);
-		if (ret)
-			BT_ERR("(bluesleep_init) failed to set ext_wake 1.");
-	}
-	*/
 	set_bit(BT_EXT_WAKE, &flags);
 
 	return 0;
@@ -1076,9 +1063,9 @@ static void __exit bluesleep_exit(void)
 		return;
 
 	/* assert bt wake */
-	if (bsi->has_ext_wake == 1) {
+	if (bsi->has_ext_wake == 1)
 		gpio_set_value(bsi->ext_wake, 1);
-	}
+
 	set_bit(BT_EXT_WAKE, &flags);
 	if (test_bit(BT_PROTO, &flags)) {
 		if (disable_irq_wake(bsi->host_wake_irq))

--- a/drivers/slimbus/slim-msm-ngd.c
+++ b/drivers/slimbus/slim-msm-ngd.c
@@ -1358,7 +1358,7 @@ static int __devinit ngd_slim_probe(struct platform_device *pdev)
 
 	/* Create IPC log context */
 	dev->ipc_slimbus_log = ipc_log_context_create(IPC_SLIMBUS_LOG_PAGES,
-						dev_name(dev->dev), 0);
+						dev_name(dev->dev));
 	if (!dev->ipc_slimbus_log)
 		dev_err(&pdev->dev, "error creating ipc_logging context\n");
 	else {

--- a/drivers/tty/n_smux.c
+++ b/drivers/tty/n_smux.c
@@ -1,6 +1,6 @@
 /* drivers/tty/n_smux.c
  *
- * Copyright (c) 2012-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2013, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -3905,7 +3905,7 @@ static int __init smux_init(void)
 		return ret;
 	}
 
-	log_ctx = ipc_log_context_create(1, "smux", 0);
+	log_ctx = ipc_log_context_create(1, "smux");
 	if (!log_ctx) {
 		SMUX_ERR("%s: unable to create log context\n", __func__);
 		disable_ipc_logging = 1;

--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -3,7 +3,7 @@
  * MSM 7k High speed uart driver
  *
  * Copyright (c) 2008 Google Inc.
- * Copyright (c) 2007-2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2007-2013, The Linux Foundation. All rights reserved.
  * Modified: Nick Pelly <npelly@google.com>
  *
  * All source code in this file is licensed under the following license
@@ -59,13 +59,16 @@
 #include <linux/of_device.h>
 #include <linux/of_gpio.h>
 #include <linux/gpio.h>
+#include <linux/ipc_logging.h>
 #include <asm/atomic.h>
 #include <asm/irq.h>
 
-#include <mach/sps.h>
+#include <mach/hardware.h>
+#include <mach/dma.h>
+#include <linux/msm-sps.h>
 #include <mach/msm_serial_hs.h>
-#include <mach/msm_bus.h>
-#include <mach/msm_ipc_logging.h>
+#include <linux/msm-bus.h>
+
 #include "msm_serial_hs_hwreg.h"
 #define UART_SPS_CONS_PERIPHERAL 0
 #define UART_SPS_PROD_PERIPHERAL 1
@@ -92,6 +95,7 @@ module_param_named(debug_mask, hs_serial_debug_mask,
 
 #define MSM_HS_DBG(x...) do { \
 	if (hs_serial_debug_mask >= DBG_LEV) { \
+		pr_debug(x); \
 		if (ipc_msm_hs_log_ctxt) \
 			ipc_log_string(ipc_msm_hs_log_ctxt, x); \
 	} \
@@ -99,6 +103,7 @@ module_param_named(debug_mask, hs_serial_debug_mask,
 
 #define MSM_HS_INFO(x...) do { \
 	if (hs_serial_debug_mask >= INFO_LEV) {\
+		pr_info(x); \
 		if (ipc_msm_hs_log_ctxt) \
 			ipc_log_string(ipc_msm_hs_log_ctxt, x); \
 	} \
@@ -122,6 +127,7 @@ module_param_named(debug_mask, hs_serial_debug_mask,
 		hs_serial_debug_mask = FATAL_LEV; \
 	} \
 } while (0)
+
 /*
  * There are 3 different kind of UART Core available on MSM.
  * High Speed UART (i.e. Legacy HSUART), GSBI based HSUART
@@ -137,7 +143,7 @@ enum flush_reason {
 	FLUSH_NONE,
 	FLUSH_DATA_READY,
 	FLUSH_DATA_INVALID,  /* values after this indicate invalid data */
-	FLUSH_IGNORE,
+	FLUSH_IGNORE = FLUSH_DATA_INVALID,
 	FLUSH_STOP,
 	FLUSH_SHUTDOWN,
 };
@@ -174,6 +180,11 @@ struct msm_hs_tx {
 	unsigned int dma_in_flight;    /* tx dma in progress */
 	enum flush_reason flush;
 	wait_queue_head_t wait;
+	struct msm_dmov_cmd xfer;
+	dmov_box *command_ptr;
+	u32 *command_ptr_ptr;
+	dma_addr_t mapped_cmd_ptr;
+	dma_addr_t mapped_cmd_ptr_ptr;
 	int tx_count;
 	dma_addr_t dma_base;
 	struct tasklet_struct tlet;
@@ -182,6 +193,11 @@ struct msm_hs_tx {
 
 struct msm_hs_rx {
 	enum flush_reason flush;
+	struct msm_dmov_cmd xfer;
+	dma_addr_t cmdptr_dmaaddr;
+	dmov_box *command_ptr;
+	u32 *command_ptr_ptr;
+	dma_addr_t mapped_cmd_ptr;
 	wait_queue_head_t wait;
 	dma_addr_t rbuffer;
 	unsigned char *buffer;
@@ -191,8 +207,6 @@ struct msm_hs_rx {
 	struct delayed_work flip_insert_work;
 	struct tasklet_struct tlet;
 	struct msm_hs_sps_ep_conn_data prod;
-	bool rx_cmd_queued;
-	bool rx_cmd_exec;
 };
 enum buffer_states {
 	NONE_PENDING = 0x0,
@@ -218,6 +232,14 @@ struct msm_hs_port {
 	struct clk *pclk;
 	struct msm_hs_tx tx;
 	struct msm_hs_rx rx;
+	/* gsbi uarts have to do additional writes to gsbi memory */
+	/* block and top control status block. The following pointers */
+	/* keep a handle to these blocks. */
+	unsigned char __iomem	*mapped_gsbi;
+	int dma_tx_channel;
+	int dma_rx_channel;
+	int dma_tx_crci;
+	int dma_rx_crci;
 	struct hrtimer clk_off_timer;  /* to poll TXEMT before clock off */
 	ktime_t clk_off_delay;
 	enum msm_hs_clk_states_e clk_state;
@@ -231,6 +253,7 @@ struct msm_hs_port {
 	struct workqueue_struct *hsuart_wq; /* hsuart workqueue */
 	struct mutex clk_mutex; /* mutex to guard against clock off/clock on */
 	struct work_struct disconnect_rx_endpoint; /* disconnect rx_endpoint */
+	bool tty_flush_receive;
 	enum uart_core_type uart_type;
 	u32 bam_handle;
 	resource_size_t bam_mem;
@@ -246,14 +269,67 @@ struct msm_hs_port {
 	u32 bus_perf_client;
 	/* BLSP UART required BUS Scaling data */
 	struct msm_bus_scale_pdata *bus_scale_table;
+	bool rx_discard_flush_issued;
 	int rx_count_callback;
 	bool rx_bam_inprogress;
-	wait_queue_head_t bam_disconnect_wait;
+	unsigned int *reg_ptr;
+};
+
+unsigned int regmap_nonblsp[UART_DM_LAST] = {
+		[UART_DM_MR1] = UARTDM_MR1_ADDR,
+		[UART_DM_MR2] = UARTDM_MR2_ADDR,
+		[UART_DM_IMR] = UARTDM_IMR_ADDR,
+		[UART_DM_SR] = UARTDM_SR_ADDR,
+		[UART_DM_CR] = UARTDM_CR_ADDR,
+		[UART_DM_CSR] = UARTDM_CSR_ADDR,
+		[UART_DM_IPR] = UARTDM_IPR_ADDR,
+		[UART_DM_ISR] = UARTDM_ISR_ADDR,
+		[UART_DM_RX_TOTAL_SNAP] = UARTDM_RX_TOTAL_SNAP_ADDR,
+		[UART_DM_TFWR] = UARTDM_TFWR_ADDR,
+		[UART_DM_RFWR] = UARTDM_RFWR_ADDR,
+		[UART_DM_RF] = UARTDM_RF_ADDR,
+		[UART_DM_TF] = UARTDM_TF_ADDR,
+		[UART_DM_MISR] = UARTDM_MISR_ADDR,
+		[UART_DM_DMRX] = UARTDM_DMRX_ADDR,
+		[UART_DM_NCF_TX] = UARTDM_NCF_TX_ADDR,
+		[UART_DM_DMEN] = UARTDM_DMEN_ADDR,
+		[UART_DM_TXFS] = UARTDM_TXFS_ADDR,
+		[UART_DM_RXFS] = UARTDM_RXFS_ADDR,
+		[UART_DM_RX_TRANS_CTRL] = UARTDM_RX_TRANS_CTRL_ADDR,
+};
+
+unsigned int regmap_blsp[UART_DM_LAST] = {
+		[UART_DM_MR1] = 0x0,
+		[UART_DM_MR2] = 0x4,
+		[UART_DM_IMR] = 0xb0,
+		[UART_DM_SR] = 0xa4,
+		[UART_DM_CR] = 0xa8,
+		[UART_DM_CSR] = 0xa0,
+		[UART_DM_IPR] = 0x18,
+		[UART_DM_ISR] = 0xb4,
+		[UART_DM_RX_TOTAL_SNAP] = 0xbc,
+		[UART_DM_TFWR] = 0x1c,
+		[UART_DM_RFWR] = 0x20,
+		[UART_DM_RF] = 0x140,
+		[UART_DM_TF] = 0x100,
+		[UART_DM_MISR] = 0xac,
+		[UART_DM_DMRX] = 0x34,
+		[UART_DM_NCF_TX] = 0x40,
+		[UART_DM_DMEN] = 0x3c,
+		[UART_DM_TXFS] = 0x4c,
+		[UART_DM_RXFS] = 0x50,
+		[UART_DM_RX_TRANS_CTRL] = 0xcc,
 };
 
 static struct of_device_id msm_hs_match_table[] = {
 	{ .compatible = "qcom,msm-hsuart-v14",
+	  .data = regmap_blsp
 	},
+	{
+	  .compatible = "qcom,msm-hsuart-v13",
+	  .data = regmap_nonblsp
+	},
+	{}
 };
 
 
@@ -282,6 +358,21 @@ static struct msm_hs_port *msm_hs_get_hs_port(int port_index);
 #define UARTDM_TO_MSM(uart_port) \
 	container_of((uart_port), struct msm_hs_port, uport)
 
+struct uart_port *msm_hs_get_port_by_id(int num)
+{
+	struct uart_port *uport;
+	struct msm_hs_port *msm_uport;
+
+	if (num < 0 || num >= UARTDM_NR)
+		return NULL;
+
+	msm_uport = msm_hs_get_hs_port(num);
+
+	uport = &(msm_uport->uport);
+
+	return uport;
+}
+
 static int msm_hs_ioctl(struct uart_port *uport, unsigned int cmd,
 						unsigned long arg)
 {
@@ -304,7 +395,8 @@ static int msm_hs_ioctl(struct uart_port *uport, unsigned int cmd,
 	case MSM_GET_UART_CLOCK_STATUS: {
 		/* Return value 0 - UART CLOCK is OFF
 		 * Return value 1 - UART CLOCK is ON */
-		MSM_HS_DBG("%s():GET UART CLOCK STATUS: cmd=%d\n", __func__, cmd);
+		MSM_HS_DBG("%s():GET UART CLOCK STATUS: cmd=%d\n", __func__,
+			 cmd);
 		spin_lock_irqsave(&msm_uport->uport.lock, flags);
 		clk_state = msm_uport->clk_state;
 		spin_unlock_irqrestore(&msm_uport->uport.lock, flags);
@@ -314,7 +406,8 @@ static int msm_hs_ioctl(struct uart_port *uport, unsigned int cmd,
 		break;
 	}
 	default: {
-		MSM_HS_DBG("%s():Unknown cmd specified: cmd=%d\n", __func__, cmd);
+		MSM_HS_DBG("%s():Unknown cmd specified: cmd=%d\n", __func__,
+			   cmd);
 		ret = -ENOIOCTLCMD;
 		break;
 	}
@@ -327,34 +420,31 @@ static int msm_hs_clock_vote(struct msm_hs_port *msm_uport)
 {
 	int rc = 0;
 
-	mutex_lock(&msm_uport->clk_mutex);
 	if (1 == atomic_inc_return(&msm_uport->clk_count)) {
 		msm_hs_bus_voting(msm_uport, BUS_SCALING);
 		/* Turn on core clk and iface clk */
-		if (msm_uport->pclk) {
-			rc = clk_prepare_enable(msm_uport->pclk);
-			if (rc) {
-				dev_err(msm_uport->uport.dev,
-					"%s: Could not turn on pclk [%d]\n",
-					__func__, rc);
-				mutex_unlock(&msm_uport->clk_mutex);
-				return rc;
-			}
-		}
-
 		rc = clk_prepare_enable(msm_uport->clk);
 		if (rc) {
+			atomic_dec(&msm_uport->clk_count);
 			dev_err(msm_uport->uport.dev,
 				"%s: Could not turn on core clk [%d]\n",
 				__func__, rc);
-			clk_disable_unprepare(msm_uport->pclk);
-			mutex_unlock(&msm_uport->clk_mutex);
 			return rc;
 		}
+
+		if (msm_uport->pclk) {
+			rc = clk_prepare_enable(msm_uport->pclk);
+			if (rc) {
+				clk_disable_unprepare(msm_uport->clk);
+				atomic_dec(&msm_uport->clk_count);
+				dev_err(msm_uport->uport.dev,
+					"%s: Could not turn on pclk [%d]\n",
+					__func__, rc);
+				return rc;
+			}
+		}
 		msm_uport->clk_state = MSM_HS_CLK_ON;
-		MSM_HS_DBG("%s: Clock ON successful\n", __func__);
 	}
-	mutex_unlock(&msm_uport->clk_mutex);
 
 
 	return rc;
@@ -362,28 +452,14 @@ static int msm_hs_clock_vote(struct msm_hs_port *msm_uport)
 
 static void msm_hs_clock_unvote(struct msm_hs_port *msm_uport)
 {
-	int rc = atomic_read(&msm_uport->clk_count);
-
-	if (rc <= 0) {
-		WARN(rc, "msm_uport->clk_count < 0!");
-		dev_err(msm_uport->uport.dev,
-			"%s: Clocks count invalid  [%d]\n", __func__, rc);
-		return;
-	}
-
-	mutex_lock(&msm_uport->clk_mutex);
-	rc = atomic_dec_return(&msm_uport->clk_count);
-	if (0 == rc) {
+	if (1 == __atomic_add_unless(&msm_uport->clk_count, -1, 0)) {
+		msm_hs_bus_voting(msm_uport, BUS_RESET);
 		/* Turn off the core clk and iface clk*/
 		clk_disable_unprepare(msm_uport->clk);
 		if (msm_uport->pclk)
 			clk_disable_unprepare(msm_uport->pclk);
-		/* Unvote the PNOC clock */
-		msm_hs_bus_voting(msm_uport, BUS_RESET);
 		msm_uport->clk_state = MSM_HS_CLK_OFF;
-		MSM_HS_DBG("%s: Clock OFF successful\n", __func__);
 	}
-	mutex_unlock(&msm_uport->clk_mutex);
 }
 
 /* Check if the uport line number matches with user id stored in pdata.
@@ -465,11 +541,21 @@ static inline unsigned int use_low_power_wakeup(struct msm_hs_port *msm_uport)
 	return (msm_uport->wakeup.irq > 0);
 }
 
+static inline int is_gsbi_uart(struct msm_hs_port *msm_uport)
+{
+	/* assume gsbi uart if gsbi resource found in pdata */
+	return ((msm_uport->mapped_gsbi != NULL));
+}
+static unsigned int is_blsp_uart(struct msm_hs_port *msm_uport)
+{
+	return (msm_uport->uart_type == BLSP_HSUART);
+}
+
 static void msm_hs_bus_voting(struct msm_hs_port *msm_uport, unsigned int vote)
 {
 	int ret;
 
-	if (msm_uport->bus_perf_client) {
+	if (is_blsp_uart(msm_uport) && msm_uport->bus_perf_client) {
 		MSM_HS_DBG("Bus voting:%d\n", vote);
 		ret = msm_bus_scale_client_update_request(
 				msm_uport->bus_perf_client, vote);
@@ -482,32 +568,22 @@ static void msm_hs_bus_voting(struct msm_hs_port *msm_uport, unsigned int vote)
 static inline unsigned int msm_hs_read(struct uart_port *uport,
 				       unsigned int index)
 {
-	return readl_relaxed(uport->membase + index);
+	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
+	unsigned int offset;
+
+	offset = *(msm_uport->reg_ptr + index);
+
+	return readl_relaxed(uport->membase + offset);
 }
 
 static inline void msm_hs_write(struct uart_port *uport, unsigned int index,
 				 unsigned int value)
 {
-	writel_relaxed(value, uport->membase + index);
-}
+	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
+	unsigned int offset;
 
-static int sps_rx_disconnect(struct sps_pipe *sps_pipe_handler)
-{
-	struct sps_connect config;
-	int ret;
-
-	ret = sps_get_config(sps_pipe_handler, &config);
-	if (ret) {
-		pr_err("%s: sps_get_config() failed ret %d\n", __func__, ret);
-		return ret;
-	}
-	config.options |= SPS_O_POLL;
-	ret = sps_set_config(sps_pipe_handler, &config);
-	if (ret) {
-		pr_err("%s: sps_set_config() failed ret %d\n", __func__, ret);
-		return ret;
-	}
-	return sps_disconnect(sps_pipe_handler);
+	offset = *(msm_uport->reg_ptr + index);
+	writel_relaxed(value, uport->membase + offset);
 }
 
 static void hex_dump_ipc(char *prefix, char *string, int size)
@@ -523,33 +599,75 @@ static void hex_dump_ipc(char *prefix, char *string, int size)
 */
 static void dump_uart_hs_registers(struct msm_hs_port *msm_uport)
 {
-	struct uart_port *uport = &(msm_uport->uport);
 	if (msm_uport->clk_state != MSM_HS_CLK_ON) {
-		MSM_HS_WARN("%s: Failed.Clocks are OFF\n", __func__);
+		MSM_HS_DBG("%s: Failed. Clocks are OFF\n", __func__);
 		return;
 	}
 
-	MSM_HS_DBG(
-	"MR1:%x MR2:%x TFWR:%x RFWR:%x DMEN:%x IMR:%x MISR:%x NCF_TX:%x\n",
-	msm_hs_read(uport, UART_DM_MR1),
-	msm_hs_read(uport, UART_DM_MR2),
-	msm_hs_read(uport, UART_DM_TFWR),
-	msm_hs_read(uport, UART_DM_RFWR),
-	msm_hs_read(uport, UART_DM_DMEN),
-	msm_hs_read(uport, UART_DM_IMR),
-	msm_hs_read(uport, UART_DM_MISR),
-	msm_hs_read(uport, UART_DM_NCF_TX));
-	MSM_HS_INFO("SR:%x ISR:%x DMRX:%x RX_SNAP:%x TXFS:%x RXFS:%x\n",
-	msm_hs_read(uport, UART_DM_SR),
-	msm_hs_read(uport, UART_DM_ISR),
-	msm_hs_read(uport, UART_DM_DMRX),
-	msm_hs_read(uport, UART_DM_RX_TOTAL_SNAP),
-	msm_hs_read(uport, UART_DM_TXFS),
-	msm_hs_read(uport, UART_DM_RXFS));
-	MSM_HS_DBG("clk_req_state:0x%x rx.flush:%u\n",
-				msm_uport->clk_req_off_state,
-					msm_uport->rx.flush);
-	MSM_HS_DBG("clk_state:%d", msm_uport->clk_state);
+	MSM_HS_DBG("============= UART Registers ================\n");
+	MSM_HS_DBG("UART_DM_MR1:%x\n", msm_hs_read(&(msm_uport->uport),
+		UART_DM_MR1));
+	MSM_HS_DBG("UART_DM_MR2:%x\n", msm_hs_read(&(msm_uport->uport),
+		UART_DM_MR2));
+	MSM_HS_DBG("UART_DM_IPR:%x\n", msm_hs_read(&(msm_uport->uport),
+		UART_DM_IPR));
+	MSM_HS_DBG("UART_DM_RFWR:%x\n", msm_hs_read(&(msm_uport->uport),
+		UART_DM_RFWR));
+	MSM_HS_DBG("UART_DM_SR:%x\n", msm_hs_read(&(msm_uport->uport),
+		UART_DM_SR));
+	MSM_HS_DBG("UART_DM_IMR: %x\n", msm_hs_read(&(msm_uport->uport),
+		UART_DM_IMR));
+	MSM_HS_DBG("=============================================\n");
+
+}
+
+static void msm_hs_release_port(struct uart_port *port)
+{
+	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(port);
+	struct platform_device *pdev = to_platform_device(port->dev);
+	struct resource *gsbi_resource;
+	resource_size_t size;
+
+	if (is_gsbi_uart(msm_uport)) {
+		iowrite32(GSBI_PROTOCOL_IDLE, msm_uport->mapped_gsbi +
+			  GSBI_CONTROL_ADDR);
+		gsbi_resource = platform_get_resource_byname(pdev,
+							     IORESOURCE_MEM,
+							     "gsbi_resource");
+		if (unlikely(!gsbi_resource))
+			return;
+
+		size = resource_size(gsbi_resource);
+		release_mem_region(gsbi_resource->start, size);
+		iounmap(msm_uport->mapped_gsbi);
+		msm_uport->mapped_gsbi = NULL;
+	}
+}
+
+static int msm_hs_request_port(struct uart_port *port)
+{
+	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(port);
+	struct platform_device *pdev = to_platform_device(port->dev);
+	struct resource *gsbi_resource;
+	resource_size_t size;
+
+	gsbi_resource = platform_get_resource_byname(pdev,
+						     IORESOURCE_MEM,
+						     "gsbi_resource");
+	if (gsbi_resource) {
+		size = resource_size(gsbi_resource);
+		if (unlikely(!request_mem_region(gsbi_resource->start, size,
+						 "msm_serial_hs")))
+			return -EBUSY;
+		msm_uport->mapped_gsbi = ioremap(gsbi_resource->start,
+						 size);
+		if (!msm_uport->mapped_gsbi) {
+			release_mem_region(gsbi_resource->start, size);
+			return -EBUSY;
+		}
+	}
+	/* no gsbi uart */
+	return 0;
 }
 
 static int msm_serial_loopback_enable_set(void *data, u64 val)
@@ -559,20 +677,31 @@ static int msm_serial_loopback_enable_set(void *data, u64 val)
 	unsigned long flags;
 	int ret = 0;
 
-	msm_hs_clock_vote(msm_uport);
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		return ret;
+	}
 
 	if (val) {
 		spin_lock_irqsave(&uport->lock, flags);
 		ret = msm_hs_read(uport, UART_DM_MR2);
-		ret |= (UARTDM_MR2_LOOP_MODE_BMSK |
-			UARTDM_MR2_RFR_CTS_LOOP_MODE_BMSK);
+		if (is_blsp_uart(msm_uport))
+			ret |= (UARTDM_MR2_LOOP_MODE_BMSK |
+				UARTDM_MR2_RFR_CTS_LOOP_MODE_BMSK);
+		else
+			ret |= UARTDM_MR2_LOOP_MODE_BMSK;
 		msm_hs_write(uport, UART_DM_MR2, ret);
 		spin_unlock_irqrestore(&uport->lock, flags);
 	} else {
 		spin_lock_irqsave(&uport->lock, flags);
 		ret = msm_hs_read(uport, UART_DM_MR2);
-		ret &= ~(UARTDM_MR2_LOOP_MODE_BMSK |
-			UARTDM_MR2_RFR_CTS_LOOP_MODE_BMSK);
+		if (is_blsp_uart(msm_uport))
+			ret &= ~(UARTDM_MR2_LOOP_MODE_BMSK |
+				UARTDM_MR2_RFR_CTS_LOOP_MODE_BMSK);
+		else
+			ret &= ~UARTDM_MR2_LOOP_MODE_BMSK;
 		msm_hs_write(uport, UART_DM_MR2, ret);
 		spin_unlock_irqrestore(&uport->lock, flags);
 	}
@@ -590,7 +719,12 @@ static int msm_serial_loopback_enable_get(void *data, u64 *val)
 	unsigned long flags;
 	int ret = 0;
 
-	msm_hs_clock_vote(msm_uport);
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		return ret;
+	}
 
 	spin_lock_irqsave(&uport->lock, flags);
 	ret = msm_hs_read(&msm_uport->uport, UART_DM_MR2);
@@ -611,7 +745,7 @@ DEFINE_SIMPLE_ATTRIBUTE(loopback_enable_fops, msm_serial_loopback_enable_get,
  * test scripts.
  * writing 0 disables the internal loopback mode. Default is disabled.
  */
-static void __devinit msm_serial_debugfs_init(struct msm_hs_port *msm_uport,
+static void msm_serial_debugfs_init(struct msm_hs_port *msm_uport,
 					   int id)
 {
 	char node_name[15];
@@ -627,14 +761,14 @@ static void __devinit msm_serial_debugfs_init(struct msm_hs_port *msm_uport,
 							__func__, id);
 }
 
-static int __devexit msm_hs_remove(struct platform_device *pdev)
+static int msm_hs_remove(struct platform_device *pdev)
 {
 
 	struct msm_hs_port *msm_uport;
 	struct device *dev;
 
 	if (pdev->id < 0 || pdev->id >= UARTDM_NR) {
-		MSM_HS_ERR(KERN_ERR "Invalid plaform device ID = %d\n", pdev->id);
+		MSM_HS_ERR("Invalid plaform device ID = %d\n", pdev->id);
 		return -EINVAL;
 	}
 
@@ -646,9 +780,18 @@ static int __devexit msm_hs_remove(struct platform_device *pdev)
 	sysfs_remove_file(&pdev->dev.kobj, &dev_attr_clock.attr);
 	debugfs_remove(msm_uport->loopback_dir);
 
+	dma_unmap_single(dev, msm_uport->rx.mapped_cmd_ptr, sizeof(dmov_box),
+			 DMA_TO_DEVICE);
 	dma_pool_free(msm_uport->rx.pool, msm_uport->rx.buffer,
 		      msm_uport->rx.rbuffer);
 	dma_pool_destroy(msm_uport->rx.pool);
+
+	dma_unmap_single(dev, msm_uport->rx.cmdptr_dmaaddr, sizeof(u32),
+			 DMA_TO_DEVICE);
+	dma_unmap_single(dev, msm_uport->tx.mapped_cmd_ptr_ptr, sizeof(u32),
+			 DMA_TO_DEVICE);
+	dma_unmap_single(dev, msm_uport->tx.mapped_cmd_ptr, sizeof(dmov_box),
+			 DMA_TO_DEVICE);
 
 	wake_lock_destroy(&msm_uport->rx.wake_lock);
 	wake_lock_destroy(&msm_uport->dma_wake_lock);
@@ -659,6 +802,14 @@ static int __devexit msm_hs_remove(struct platform_device *pdev)
 	clk_put(msm_uport->clk);
 	if (msm_uport->pclk)
 		clk_put(msm_uport->pclk);
+
+	/* Free the tx resources */
+	kfree(msm_uport->tx.command_ptr);
+	kfree(msm_uport->tx.command_ptr_ptr);
+
+	/* Free the rx resources */
+	kfree(msm_uport->rx.command_ptr);
+	kfree(msm_uport->rx.command_ptr_ptr);
 
 	iounmap(msm_uport->uport.membase);
 
@@ -711,14 +862,14 @@ static int msm_hs_spsconnect_tx(struct uart_port *uport)
 	ret = sps_connect(sps_pipe_handle, sps_config);
 	if (ret) {
 		MSM_HS_ERR("msm_serial_hs: sps_connect() failed for tx!!\n"
-		"pipe_handle=0x%p ret=%d", sps_pipe_handle, ret);
+		"pipe_handle=0x%x ret=%d", (u32)sps_pipe_handle, ret);
 		return ret;
 	}
 	/* Register callback event for EOT (End of transfer) event. */
 	ret = sps_register_event(sps_pipe_handle, sps_event);
 	if (ret) {
 		MSM_HS_ERR("msm_serial_hs: sps_connect() failed for tx!!\n"
-		"pipe_handle=0x%p ret=%d", sps_pipe_handle, ret);
+		"pipe_handle=0x%x ret=%d", (u32)sps_pipe_handle, ret);
 		goto reg_event_err;
 	}
 	return 0;
@@ -752,14 +903,14 @@ static int msm_hs_spsconnect_rx(struct uart_port *uport)
 	ret = sps_connect(sps_pipe_handle, sps_config);
 	if (ret) {
 		MSM_HS_ERR("msm_serial_hs: sps_connect() failed for rx!!\n"
-		"pipe_handle=0x%p ret=%d", sps_pipe_handle, ret);
+		"pipe_handle=0x%x ret=%d", (u32)sps_pipe_handle, ret);
 		return ret;
 	}
 	/* Register callback event for DESC_DONE event. */
 	ret = sps_register_event(sps_pipe_handle, sps_event);
 	if (ret) {
 		MSM_HS_ERR("msm_serial_hs: sps_connect() failed for rx!!\n"
-		"pipe_handle=0x%p ret=%d", sps_pipe_handle, ret);
+		"pipe_handle=0x%x ret=%d", (u32)sps_pipe_handle, ret);
 		goto reg_event_err;
 	}
 	return 0;
@@ -875,15 +1026,17 @@ static void msm_hs_set_bps_locked(struct uart_port *uport,
 	mb();
 	if (bps > 460800) {
 		uport->uartclk = bps * 16;
-		/* BLSP based UART supports maximum clock frequency
-		 * of 63.16 Mhz. With this (63.16 Mhz) clock frequency
-		 * UART can support baud rate of 3.94 Mbps which is
-		 * equivalent to 4 Mbps.
-		 * UART hardware is robust enough to handle this
-		 * deviation to achieve baud rate ~4 Mbps.
-		 */
-		if (bps == 4000000)
-			uport->uartclk = BLSP_UART_CLK_FMAX;
+		if (is_blsp_uart(msm_uport)) {
+			/* BLSP based UART supports maximum clock frequency
+			 * of 63.16 Mhz. With this (63.16 Mhz) clock frequency
+			 * UART can support baud rate of 3.94 Mbps which is
+			 * equivalent to 4 Mbps.
+			 * UART hardware is robust enough to handle this
+			 * deviation to achieve baud rate ~4 Mbps.
+			 */
+			if (bps == 4000000)
+				uport->uartclk = BLSP_UART_CLK_FMAX;
+		}
 	} else {
 		uport->uartclk = 7372800;
 	}
@@ -975,12 +1128,13 @@ static void msm_hs_set_termios(struct uart_port *uport,
 	struct msm_hs_rx *rx = &msm_uport->rx;
 	struct sps_pipe *sps_pipe_handle = rx->prod.pipe_handle;
 
-	/**
-	 * set_termios can be invoked from the framework when
-	 * the clocks are off and the client has not had a chance
-	 * to turn them on. Make sure that they are on
-	 */
-	msm_hs_clock_vote(msm_uport);
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		return;
+	}
+
 	mutex_lock(&msm_uport->clk_mutex);
 	msm_hs_write(uport, UART_DM_IMR, 0);
 
@@ -994,8 +1148,6 @@ static void msm_hs_set_termios(struct uart_port *uport,
 	data = msm_hs_read(uport, UART_DM_MR1);
 	data &= ~UARTDM_MR1_RX_RDY_CTL_BMSK;
 	msm_hs_write(uport, UART_DM_MR1, data);
-	/* set RFR_N to high */
-	msm_hs_write(uport, UART_DM_CR, RFR_HIGH);
 
 	/*
 	 * Disable Rx channel of UARTDM
@@ -1007,8 +1159,12 @@ static void msm_hs_set_termios(struct uart_port *uport,
 	 * suggested to do disable/reset or reset/disable at the same time.
 	 */
 	data = msm_hs_read(uport, UART_DM_DMEN);
-	/* Disable UARTDM RX BAM Interface */
-	data &= ~UARTDM_RX_BAM_ENABLE_BMSK;
+	if (is_blsp_uart(msm_uport)) {
+		/* Disable UARTDM RX BAM Interface */
+		data &= ~UARTDM_RX_BAM_ENABLE_BMSK;
+	} else {
+		data &= ~UARTDM_RX_DM_EN_BMSK;
+	}
 
 	msm_hs_write(uport, UART_DM_DMEN, data);
 
@@ -1078,24 +1234,40 @@ static void msm_hs_set_termios(struct uart_port *uport,
 
 	msm_hs_write(uport, UART_DM_CR, RESET_RX);
 	msm_hs_write(uport, UART_DM_CR, RESET_TX);
-	/* Issue TX BAM Start IFC command */
-	msm_hs_write(uport, UART_DM_CR, START_TX_BAM_IFC);
 
 	if (msm_uport->rx.flush == FLUSH_NONE) {
 		wake_lock(&msm_uport->rx.wake_lock);
-		msm_uport->rx.flush = FLUSH_DATA_INVALID;
-		mb();
-		if (msm_uport->rx_bam_inprogress)
-			ret = wait_event_timeout(msm_uport->rx.wait,
-				msm_uport->rx_bam_inprogress == false,
-				RX_FLUSH_COMPLETE_TIMEOUT);
-		ret = sps_rx_disconnect(sps_pipe_handle);
-		if (ret)
-			MSM_HS_ERR("%s(): sps_disconnect failed\n",
-						__func__);
-		msm_hs_spsconnect_rx(uport);
 		msm_uport->rx.flush = FLUSH_IGNORE;
-		msm_serial_hs_rx_tlet((unsigned long) &rx->tlet);
+		/*
+		 * Before using dmov APIs make sure that
+		 * previous writel are completed. Hence
+		 * dsb requires here.
+		 */
+		mb();
+		if (is_blsp_uart(msm_uport)) {
+			if (msm_uport->rx_bam_inprogress)
+				ret = wait_event_timeout(msm_uport->rx.wait,
+					msm_uport->rx_bam_inprogress == false,
+					RX_FLUSH_COMPLETE_TIMEOUT);
+			ret = sps_disconnect(sps_pipe_handle);
+			if (ret)
+				MSM_HS_ERR("%s(): sps_disconnect failed\n",
+							__func__);
+			msm_hs_spsconnect_rx(uport);
+			msm_serial_hs_rx_tlet((unsigned long) &rx->tlet);
+		} else {
+			msm_uport->rx_discard_flush_issued = true;
+			/* do discard flush */
+			msm_dmov_flush(msm_uport->dma_rx_channel, 0);
+			MSM_HS_DBG("%s(): wainting for flush completion.\n",
+								__func__);
+			ret = wait_event_timeout(msm_uport->rx.wait,
+				msm_uport->rx_discard_flush_issued == false,
+				RX_FLUSH_COMPLETE_TIMEOUT);
+			if (!ret)
+				MSM_HS_ERR("%s(): Discard flush pending.\n",
+								__func__);
+		}
 	}
 
 	/* Configure HW flow control
@@ -1104,8 +1276,6 @@ static void msm_hs_set_termios(struct uart_port *uport,
 	 * UART Core would trigger RFR if it is not having any space with
 	 * RX FIFO.
 	 */
-	/* Pulling RFR line high */
-	msm_hs_write(uport, UART_DM_CR, RFR_LOW);
 	data = msm_hs_read(uport, UART_DM_MR1);
 	data &= ~(UARTDM_MR1_CTS_CTL_BMSK | UARTDM_MR1_RX_RDY_CTL_BMSK);
 	if (c_cflag & CRTSCTS) {
@@ -1117,8 +1287,10 @@ static void msm_hs_set_termios(struct uart_port *uport,
 	msm_hs_write(uport, UART_DM_IMR, msm_uport->imr_reg);
 	mb();
 	mutex_unlock(&msm_uport->clk_mutex);
+
 	MSM_HS_DBG("Exit %s\n", __func__);
 	dump_uart_hs_registers(msm_uport);
+
 	msm_hs_clock_unvote(msm_uport);
 }
 
@@ -1132,15 +1304,14 @@ unsigned int msm_hs_tx_empty(struct uart_port *uport)
 	unsigned int ret = 0;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 
-	if (msm_uport->clk_state == MSM_HS_CLK_PORT_OFF) {
-		MSM_HS_ERR("%s:UART port is closed\n", __func__);
-		return -EPERM;
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		return ret;
 	}
-
-	msm_hs_clock_vote(msm_uport);
 	data = msm_hs_read(uport, UART_DM_SR);
 	msm_hs_clock_unvote(msm_uport);
-	MSM_HS_DBG("%s(): SR Reg Read 0x%x", __func__, data);
 
 	if (data & UARTDM_SR_TXEMT_BMSK)
 		ret = TIOCSER_TEMT;
@@ -1166,29 +1337,16 @@ static void hsuart_disconnect_rx_endpoint_work(struct work_struct *w)
 {
 	struct msm_hs_port *msm_uport = container_of(w, struct msm_hs_port,
 						disconnect_rx_endpoint);
-	struct uart_port *uport = &msm_uport->uport;
 	struct msm_hs_rx *rx = &msm_uport->rx;
 	struct sps_pipe *sps_pipe_handle = rx->prod.pipe_handle;
-	struct platform_device *pdev = to_platform_device(uport->dev);
-	const struct msm_serial_hs_platform_data *pdata =
-					pdev->dev.platform_data;
 	int ret = 0;
 
-	msm_hs_clock_vote(msm_uport);
-	ret = sps_rx_disconnect(sps_pipe_handle);
-	msm_hs_clock_unvote(msm_uport);
-
+	ret = sps_disconnect(sps_pipe_handle);
 	if (ret)
 		MSM_HS_ERR("%s(): sps_disconnect failed\n", __func__);
-	if (pdata->no_suspend_delay)
-		wake_unlock(&msm_uport->rx.wake_lock);
-	else
-		wake_lock_timeout(&msm_uport->rx.wake_lock,
-						HZ / 2);
+
+	wake_lock_timeout(&msm_uport->rx.wake_lock, HZ / 2);
 	msm_uport->rx.flush = FLUSH_SHUTDOWN;
-	MSM_HS_DBG("%s: Calling Completion\n", __func__);
-	wake_up(&msm_uport->bam_disconnect_wait);
-	MSM_HS_DBG("%s: Done Completion\n", __func__);
 	wake_up(&msm_uport->rx.wait);
 }
 
@@ -1205,24 +1363,35 @@ static void msm_hs_stop_rx_locked(struct uart_port *uport)
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 	unsigned int data;
 
-	MSM_HS_DBG("In %s():\n", __func__);
-	if (msm_uport->clk_state != MSM_HS_CLK_OFF) {
-		/* disable dlink */
-		data = msm_hs_read(uport, UART_DM_DMEN);
-		data &= ~UARTDM_RX_BAM_ENABLE_BMSK;
-		msm_hs_write(uport, UART_DM_DMEN, data);
+	if (msm_uport->clk_state <= MSM_HS_CLK_OFF)
+		return;
 
-		/* calling DMOV or CLOCK API. Hence mb() */
-		mb();
-	}
+	/* disable dlink */
+	data = msm_hs_read(uport, UART_DM_DMEN);
+	if (is_blsp_uart(msm_uport))
+		data &= ~UARTDM_RX_BAM_ENABLE_BMSK;
+	else
+		data &= ~UARTDM_RX_DM_EN_BMSK;
+	msm_hs_write(uport, UART_DM_DMEN, data);
+
+	/* calling DMOV or CLOCK API. Hence mb() */
+	mb();
 	/* Disable the receiver */
 	if (msm_uport->rx.flush == FLUSH_NONE) {
 		wake_lock(&msm_uport->rx.wake_lock);
-		msm_uport->rx.flush = FLUSH_STOP;
-		/* workqueue for BAM rx endpoint disconnect */
-		queue_work(msm_uport->hsuart_wq,
-			&msm_uport->disconnect_rx_endpoint);
+		if (is_blsp_uart(msm_uport)) {
+			msm_uport->rx.flush = FLUSH_STOP;
+			/* workqueue for BAM rx endpoint disconnect */
+			queue_work(msm_uport->hsuart_wq,
+				&msm_uport->disconnect_rx_endpoint);
+		} else {
+			/* do discard flush */
+			msm_dmov_flush(msm_uport->dma_rx_channel, 0);
+		}
 	}
+	if (!is_blsp_uart(msm_uport) && msm_uport->rx.flush != FLUSH_SHUTDOWN)
+		msm_uport->rx.flush = FLUSH_STOP;
+
 }
 
 /*  Transmit the next chunk of data */
@@ -1233,23 +1402,14 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 	int aligned_tx_count;
 	dma_addr_t src_addr;
 	dma_addr_t aligned_src_addr;
-	u32 flags = SPS_IOVEC_FLAG_EOT | SPS_IOVEC_FLAG_INT;
+	u32 flags = SPS_IOVEC_FLAG_EOT;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 	struct msm_hs_tx *tx = &msm_uport->tx;
 	struct circ_buf *tx_buf = &msm_uport->uport.state->xmit;
 	struct sps_pipe *sps_pipe_handle;
-	struct platform_device *pdev = to_platform_device(uport->dev);
-	char * buff = tx_buf->buf+tx_buf->tail;
 
 	if (uart_circ_empty(tx_buf) || uport->state->port.tty->stopped) {
 		msm_hs_stop_tx_locked(uport);
-		if (msm_uport->clk_state == MSM_HS_CLK_REQUEST_OFF) {
-			MSM_HS_DBG("%s(): Clock off requested calling WQ",
-								__func__);
-			queue_work(msm_uport->hsuart_wq,
-						&msm_uport->clock_off_w);
-			wake_up(&msm_uport->tx.wait);
-		}
 		return;
 	}
 
@@ -1267,11 +1427,6 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 	MSM_HS_DBG("%s(): [UART_TX]<%d>\n", __func__, tx_count);
 	hex_dump_ipc("HSUART write: ", &tx_buf->buf[tx_buf->tail], tx_count);
 	src_addr = tx->dma_base + tx_buf->tail;
-
-	if (pdev->id == 0 && tx_count == 4 && buff[0] == 0x1 && buff[1] == 0x3 && buff[2] == 0xc && buff[3] == 0x0) {
-		printk(KERN_ERR "(msm_serial_hs) hci_reset was received at ttyHS0 port\n");
-	}
-
 	/* Mask the src_addr to align on a cache
 	 * and add those bytes to tx_count */
 	aligned_src_addr = src_addr & ~(dma_get_cache_alignment() - 1);
@@ -1280,15 +1435,45 @@ static void msm_hs_submit_tx_locked(struct uart_port *uport)
 	dma_sync_single_for_device(uport->dev, aligned_src_addr,
 			aligned_tx_count, DMA_TO_DEVICE);
 
+	if (is_blsp_uart(msm_uport)) {
+		/* Issue TX BAM Start IFC command */
+		msm_hs_write(uport, UART_DM_CR, START_TX_BAM_IFC);
+	} else {
+		tx->command_ptr->num_rows =
+				(((tx_count + 15) >> 4) << 16) |
+				((tx_count + 15) >> 4);
+		tx->command_ptr->src_row_addr = src_addr;
+
+		dma_sync_single_for_device(uport->dev, tx->mapped_cmd_ptr,
+				sizeof(dmov_box), DMA_TO_DEVICE);
+
+		*tx->command_ptr_ptr = CMD_PTR_LP |
+				DMOV_CMD_ADDR(tx->mapped_cmd_ptr);
+	}
+
+	/* Save tx_count to use in Callback */
 	tx->tx_count = tx_count;
+	msm_hs_write(uport, UART_DM_NCF_TX, tx_count);
+
+	/* Disable the tx_ready interrupt */
+	msm_uport->imr_reg &= ~UARTDM_ISR_TX_READY_BMSK;
+	msm_hs_write(uport, UART_DM_IMR, msm_uport->imr_reg);
+	/* Calling next DMOV API. Hence mb() here. */
+	mb();
 
 	msm_uport->tx.flush = FLUSH_NONE;
 
-	sps_pipe_handle = tx->cons.pipe_handle;
-	/* Queue transfer request to SPS */
-	sps_transfer_one(sps_pipe_handle, src_addr, tx_count,
-				msm_uport, flags);
+	if (is_blsp_uart(msm_uport)) {
+		sps_pipe_handle = tx->cons.pipe_handle;
+		/* Queue transfer request to SPS */
+		sps_transfer_one(sps_pipe_handle, src_addr, tx_count,
+					msm_uport, flags);
+	} else {
+		dma_sync_single_for_device(uport->dev, tx->mapped_cmd_ptr_ptr,
+			sizeof(u32), DMA_TO_DEVICE);
 
+		msm_dmov_enqueue_cmd(msm_uport->dma_tx_channel, &tx->xfer);
+	}
 	MSM_HS_DBG("%s:Enqueue Tx Cmd\n", __func__);
 	dump_uart_hs_registers(msm_uport);
 }
@@ -1303,57 +1488,60 @@ static void msm_hs_start_rx_locked(struct uart_port *uport)
 	unsigned int buffer_pending = msm_uport->rx.buffer_pending;
 	unsigned int data;
 
-	if (msm_uport->clk_state != MSM_HS_CLK_ON) {
-		MSM_HS_WARN("%s: Failed.Clocks are OFF\n", __func__);
-		return;
-	}
-	if (rx->rx_cmd_exec) {
-		MSM_HS_DBG("%s: Rx Cmd got executed, wait for rx_tlet\n",
-								 __func__);
-		rx->flush = FLUSH_IGNORE;
-		return;
-	}
 	msm_uport->rx.buffer_pending = 0;
-	if (buffer_pending && hs_serial_debug_mask)
-		MSM_HS_ERR("Error: rx started in buffer state = %x",
-		       buffer_pending);
+	if (buffer_pending)
+		MSM_HS_ERR("Error: rx started in buffer state =%x",
+			buffer_pending);
 
 	msm_hs_write(uport, UART_DM_CR, RESET_STALE_INT);
 	msm_hs_write(uport, UART_DM_DMRX, UARTDM_RX_BUF_SIZE);
 	msm_hs_write(uport, UART_DM_CR, STALE_EVENT_ENABLE);
+	msm_uport->imr_reg |= UARTDM_ISR_RXLEV_BMSK;
+
 	/*
 	 * Enable UARTDM Rx Interface as previously it has been
 	 * disable in set_termios before configuring baud rate.
 	 */
 	data = msm_hs_read(uport, UART_DM_DMEN);
-	/* Enable UARTDM Rx BAM Interface */
-	data |= UARTDM_RX_BAM_ENABLE_BMSK;
+	if (is_blsp_uart(msm_uport)) {
+		/* Enable UARTDM Rx BAM Interface */
+		data |= UARTDM_RX_BAM_ENABLE_BMSK;
+	} else {
+		data |= UARTDM_RX_DM_EN_BMSK;
+	}
 
 	msm_hs_write(uport, UART_DM_DMEN, data);
 	msm_hs_write(uport, UART_DM_IMR, msm_uport->imr_reg);
 	/* Calling next DMOV API. Hence mb() here. */
 	mb();
 
-	/*
-	 * RX-transfer will be automatically re-activated
-	 * after last data of previous transfer was read.
-	 */
-	data = (RX_STALE_AUTO_RE_EN | RX_TRANS_AUTO_RE_ACTIVATE |
-				RX_DMRX_CYCLIC_EN);
-	msm_hs_write(uport, UART_DM_RX_TRANS_CTRL, data);
-	/* Issue RX BAM Start IFC command */
-	msm_hs_write(uport, UART_DM_CR, START_RX_BAM_IFC);
-	mb();
+	if (is_blsp_uart(msm_uport)) {
+		/*
+		 * RX-transfer will be automatically re-activated
+		 * after last data of previous transfer was read.
+		 */
+		data = (RX_STALE_AUTO_RE_EN | RX_TRANS_AUTO_RE_ACTIVATE |
+					RX_DMRX_CYCLIC_EN);
+		msm_hs_write(uport, UART_DM_RX_TRANS_CTRL, data);
+		/* Issue RX BAM Start IFC command */
+		msm_hs_write(uport, UART_DM_CR, START_RX_BAM_IFC);
+		mb();
+	}
 
 	msm_uport->rx.flush = FLUSH_NONE;
-	msm_uport->rx_bam_inprogress = true;
-	sps_pipe_handle = rx->prod.pipe_handle;
-	/* Queue transfer request to SPS */
-	sps_transfer_one(sps_pipe_handle, rx->rbuffer,
-		UARTDM_RX_BUF_SIZE, msm_uport, flags);
-	msm_uport->rx_bam_inprogress = false;
-	msm_uport->rx.rx_cmd_queued = true;
-	wake_up(&msm_uport->rx.wait);
+
+	if (is_blsp_uart(msm_uport)) {
+		msm_uport->rx_bam_inprogress = true;
+		sps_pipe_handle = rx->prod.pipe_handle;
+		/* Queue transfer request to SPS */
+		sps_transfer_one(sps_pipe_handle, rx->rbuffer,
+			UARTDM_RX_BUF_SIZE, msm_uport, flags);
+		msm_uport->rx_bam_inprogress = false;
+		wake_up(&msm_uport->rx.wait);
+	} else {
+		msm_dmov_enqueue_cmd(msm_uport->dma_rx_channel,
+				&msm_uport->rx.xfer);
+	}
 	MSM_HS_DBG("%s:Enqueue Rx Cmd\n", __func__);
 	dump_uart_hs_registers(msm_uport);
 }
@@ -1369,9 +1557,7 @@ static void flip_insert_work(struct work_struct *work)
 
 	spin_lock_irqsave(&msm_uport->uport.lock, flags);
 	if (msm_uport->rx.buffer_pending == NONE_PENDING) {
-		if (hs_serial_debug_mask)
-			MSM_HS_ERR("Error: No buffer pending in %s",
-			       __func__);
+		MSM_HS_ERR("Error: No buffer pending in %s", __func__);
 		return;
 	}
 	if (msm_uport->rx.buffer_pending & FIFO_OVERRUN) {
@@ -1388,7 +1574,8 @@ static void flip_insert_work(struct work_struct *work)
 		int rx_count, rx_offset;
 		rx_count = (msm_uport->rx.buffer_pending & 0xFFFF0000) >> 16;
 		rx_offset = (msm_uport->rx.buffer_pending & 0xFFD0) >> 5;
-		retval = tty_insert_flip_string(tty, msm_uport->rx.buffer +
+		retval = tty_insert_flip_string(tty,
+						msm_uport->rx.buffer +
 						rx_offset, rx_count);
 		msm_uport->rx.buffer_pending &= (FIFO_OVERRUN |
 						 PARITY_ERROR);
@@ -1399,10 +1586,9 @@ static void flip_insert_work(struct work_struct *work)
 	if (msm_uport->rx.buffer_pending)
 		schedule_delayed_work(&msm_uport->rx.flip_insert_work,
 				      msecs_to_jiffies(RETRY_TIMEOUT));
-	else
-		if ((msm_uport->clk_state == MSM_HS_CLK_ON) &&
-		    (msm_uport->rx.flush <= FLUSH_IGNORE)) {
-		MSM_HS_WARN("Pending buffers cleared,restarting\n");
+	else if ((msm_uport->clk_state == MSM_HS_CLK_ON) &&
+		 (msm_uport->rx.flush <= FLUSH_IGNORE)) {
+			MSM_HS_WARN("Pending buffers cleared, restarting");
 			msm_hs_start_rx_locked(&msm_uport->uport);
 		}
 	spin_unlock_irqrestore(&msm_uport->uport.lock, flags);
@@ -1412,7 +1598,7 @@ static void flip_insert_work(struct work_struct *work)
 static void msm_serial_hs_rx_tlet(unsigned long tlet_ptr)
 {
 	int retval;
-	int rx_count = 0;
+	int rx_count;
 	unsigned long status;
 	unsigned long flags;
 	unsigned int error_f = 0;
@@ -1424,8 +1610,6 @@ static void msm_serial_hs_rx_tlet(unsigned long tlet_ptr)
 	struct msm_hs_rx *rx;
 	struct sps_pipe *sps_pipe_handle;
 	u32 sps_flags = SPS_IOVEC_FLAG_INT;
-	struct platform_device *pdev;
-	const struct msm_serial_hs_platform_data *pdata;
 
 	msm_uport = container_of((struct tasklet_struct *)tlet_ptr,
 				 struct msm_hs_port, rx.tlet);
@@ -1433,15 +1617,13 @@ static void msm_serial_hs_rx_tlet(unsigned long tlet_ptr)
 	tty = uport->state->port.tty;
 	notify = &msm_uport->notify;
 	rx = &msm_uport->rx;
-	pdev = to_platform_device(uport->dev);
-	pdata = pdev->dev.platform_data;
-
-	msm_uport->rx.rx_cmd_queued = false;
-	msm_uport->rx.rx_cmd_exec = false;
 
 	status = msm_hs_read(uport, UART_DM_SR);
 
 	spin_lock_irqsave(&uport->lock, flags);
+
+	if (!is_blsp_uart(msm_uport))
+		msm_hs_write(uport, UART_DM_CR, STALE_EVENT_DISABLE);
 
 	MSM_HS_DBG("In %s\n", __func__);
 	dump_uart_hs_registers(msm_uport);
@@ -1461,8 +1643,7 @@ static void msm_serial_hs_rx_tlet(unsigned long tlet_ptr)
 
 	if (unlikely(status & UARTDM_SR_PAR_FRAME_BMSK)) {
 		/* Can not tell difference between parity & frame error */
-		if (hs_serial_debug_mask)
-			MSM_HS_WARN("msm_serial_hs: parity error\n");
+		MSM_HS_WARN("msm_serial_hs: parity error\n");
 		uport->icount.parity++;
 		error_f = 1;
 		if (!(uport->ignore_status_mask & IGNPAR)) {
@@ -1473,8 +1654,7 @@ static void msm_serial_hs_rx_tlet(unsigned long tlet_ptr)
 	}
 
 	if (unlikely(status & UARTDM_SR_RX_BREAK_BMSK)) {
-		if (hs_serial_debug_mask)
-			MSM_HS_WARN("msm_serial_hs: Rx break\n");
+		MSM_HS_WARN("msm_serial_hs: Rx break\n");
 		uport->icount.brk++;
 		error_f = 1;
 		if (!(uport->ignore_status_mask & IGNBRK)) {
@@ -1484,60 +1664,72 @@ static void msm_serial_hs_rx_tlet(unsigned long tlet_ptr)
 		}
 	}
 
-	if (error_f) {
-		if (msm_uport->clk_state == MSM_HS_CLK_ON)
-			msm_hs_write(uport, UART_DM_CR, RESET_ERROR_STATUS);
-		else
-			MSM_HS_WARN("%s: Failed.Clocks are OFF\n", __func__);
-	}
+	if (error_f)
+		msm_hs_write(uport, UART_DM_CR, RESET_ERROR_STATUS);
+
+	if (msm_uport->clk_req_off_state == CLK_REQ_OFF_FLUSH_ISSUED)
+		msm_uport->clk_req_off_state = CLK_REQ_OFF_RXSTALE_FLUSHED;
 	flush = msm_uport->rx.flush;
 	if (flush == FLUSH_IGNORE)
-		if (!msm_uport->rx.buffer_pending) {
-			MSM_HS_DBG("%s: calling start_rx_locked\n", __func__);
+		if (!msm_uport->rx.buffer_pending)
 			msm_hs_start_rx_locked(uport);
-		}
+
+	if (flush == FLUSH_STOP) {
+		msm_uport->rx.flush = FLUSH_SHUTDOWN;
+		wake_up(&msm_uport->rx.wait);
+	}
 	if (flush >= FLUSH_DATA_INVALID)
 		goto out;
 
-	rx_count = msm_uport->rx_count_callback;
+	if (is_blsp_uart(msm_uport)) {
+		rx_count = msm_uport->rx_count_callback;
+	} else {
+		rx_count = msm_hs_read(uport, UART_DM_RX_TOTAL_SNAP);
+		/* order the read of rx.buffer */
+		rmb();
+	}
 
 	MSM_HS_DBG("%s():[UART_RX]<%d>\n", __func__, rx_count);
 	hex_dump_ipc("HSUART Read: ", msm_uport->rx.buffer, rx_count);
+
 	if (0 != (uport->read_status_mask & CREAD)) {
 		retval = tty_insert_flip_string(tty, msm_uport->rx.buffer,
 						rx_count);
 		if (retval != rx_count) {
 			MSM_HS_DBG("%s(): retval %d rx_count %d", __func__,
-					retval, rx_count);
+				retval, rx_count);
 			msm_uport->rx.buffer_pending |= CHARS_NORMAL |
 				retval << 5 | (rx_count - retval) << 16;
 		}
 	}
-	if (!msm_uport->rx.buffer_pending && !msm_uport->rx.rx_cmd_queued) {
-		msm_uport->rx.flush = FLUSH_NONE;
-		msm_uport->rx_bam_inprogress = true;
-		sps_pipe_handle = rx->prod.pipe_handle;
-		MSM_HS_DBG("Queing bam descriptor\n");
-		/* Queue transfer request to SPS */
-		sps_transfer_one(sps_pipe_handle, rx->rbuffer,
-			UARTDM_RX_BUF_SIZE, msm_uport, sps_flags);
-		msm_uport->rx_bam_inprogress = false;
-		msm_uport->rx.rx_cmd_queued = true;
-		wake_up(&msm_uport->rx.wait);
+
+	MSM_HS_DBG("%s() read rx buffer complete", __func__);
+	/* order the read of rx.buffer and the start of next rx xfer */
+	wmb();
+
+	if (!msm_uport->rx.buffer_pending) {
+		if (is_blsp_uart(msm_uport)) {
+			msm_uport->rx.flush = FLUSH_NONE;
+			msm_uport->rx_bam_inprogress = true;
+			sps_pipe_handle = rx->prod.pipe_handle;
+			/* Queue transfer request to SPS */
+			sps_transfer_one(sps_pipe_handle, rx->rbuffer,
+				UARTDM_RX_BUF_SIZE, msm_uport, sps_flags);
+			msm_uport->rx_bam_inprogress = false;
+			wake_up(&msm_uport->rx.wait);
+		} else {
+			msm_hs_start_rx_locked(uport);
+		}
 	}
 out:
 	if (msm_uport->rx.buffer_pending) {
-		MSM_HS_WARN("tty buffer exhausted.Stalling\n");
+		MSM_HS_WARN("tty buffer exhausted. Stalling\n");
 		schedule_delayed_work(&msm_uport->rx.flip_insert_work
 				      , msecs_to_jiffies(RETRY_TIMEOUT));
 	}
 	/* release wakelock in 500ms, not immediately, because higher layers
-	 * don't always take wakelocks when they should
-	 */
-	if (pdata->no_suspend_delay)
-		wake_unlock(&msm_uport->rx.wake_lock);
-	else
-		wake_lock_timeout(&msm_uport->rx.wake_lock, HZ / 2);
+	 * don't always take wakelocks when they should */
+	wake_lock_timeout(&msm_uport->rx.wake_lock, HZ / 2);
 	/* tty_flip_buffer_push() might call msm_hs_start(), so unlock */
 	spin_unlock_irqrestore(&uport->lock, flags);
 	if (flush < FLUSH_DATA_INVALID)
@@ -1549,13 +1741,14 @@ static void msm_hs_start_tx_locked(struct uart_port *uport )
 {
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 
-	if (msm_uport->clk_state != MSM_HS_CLK_ON) {
-		MSM_HS_WARN("%s: Failed.Clocks are OFF\n", __func__);
+	if (msm_uport->clk_state <= MSM_HS_CLK_OFF)
 		return;
-	}
-	if ((msm_uport->tx.tx_ready_int_en == 0) &&
-		(msm_uport->tx.dma_in_flight == 0))
+
+	if (msm_uport->tx.tx_ready_int_en == 0) {
+		msm_uport->tx.tx_ready_int_en = 1;
+		if (msm_uport->tx.dma_in_flight == 0)
 			msm_hs_submit_tx_locked(uport);
+	}
 }
 
 /**
@@ -1574,12 +1767,35 @@ static void msm_hs_sps_tx_callback(struct sps_event_notify *notify)
 		((struct sps_event_notify *)notify)->user;
 
 	msm_uport->notify = *notify;
-	MSM_HS_DBG("%s: ev_id=%d, addr=0x%x, size=0x%x, flags=0x%x, line=%d\n",
-		 __func__, notify->event_id,
-	notify->data.transfer.iovec.addr,
-	notify->data.transfer.iovec.size,
-	notify->data.transfer.iovec.flags,
-	msm_uport->uport.line);
+	MSM_HS_DBG("%s: sps ev_id=%d, addr=0x%x, size=0x%x, flags=0x%x\n",
+		__func__, notify->event_id,
+		notify->data.transfer.iovec.addr,
+		notify->data.transfer.iovec.size,
+		notify->data.transfer.iovec.flags);
+
+	tasklet_schedule(&msm_uport->tx.tlet);
+}
+
+/*
+ *  This routine is called when we are done with a DMA transfer
+ *
+ *  This routine is registered with Data mover when we set
+ *  up a Data Mover transfer. It is called from Data mover ISR
+ *  when the DMA transfer is done.
+ */
+static void msm_hs_dmov_tx_callback(struct msm_dmov_cmd *cmd_ptr,
+					unsigned int result,
+					struct msm_dmov_errdata *err)
+{
+	struct msm_hs_port *msm_uport;
+
+	msm_uport = container_of(cmd_ptr, struct msm_hs_port, tx.xfer);
+	if (msm_uport->tx.flush == FLUSH_STOP)
+		/* DMA FLUSH unsuccesfful */
+		WARN_ON(!(result & DMOV_RSLT_FLUSH));
+	else
+		/* DMA did not finish properly */
+		WARN_ON(!(result & DMOV_RSLT_DONE));
 
 	tasklet_schedule(&msm_uport->tx.tlet);
 }
@@ -1589,43 +1805,19 @@ static void msm_serial_hs_tx_tlet(unsigned long tlet_ptr)
 	unsigned long flags;
 	struct msm_hs_port *msm_uport = container_of((struct tasklet_struct *)
 				tlet_ptr, struct msm_hs_port, tx.tlet);
-	struct uart_port *uport = &msm_uport->uport;
-	struct circ_buf *tx_buf = &uport->state->xmit;
-	struct msm_hs_tx *tx = &msm_uport->tx;
 
-	/*
-	 * Do the work buffer related work in BAM
-	 * mode that is equivalent to legacy mode
-	 */
 	spin_lock_irqsave(&(msm_uport->uport.lock), flags);
-
-	if (!uart_circ_empty(tx_buf))
-		tx_buf->tail = (tx_buf->tail +
-		tx->tx_count) & ~UART_XMIT_SIZE;
-	else
-		MSM_HS_DBG("%s:circ buffer is empty\n", __func__);
-
-	tx->dma_in_flight = 0;
-
-	uport->icount.tx += tx->tx_count;
-
-	/*
-	 * Calling to send next chunk of data
-	 * If the circ buffer is empty, we stop
-	 * If the clock off was requested, the clock
-	 * off sequence is kicked off
-	 */
-	 msm_hs_submit_tx_locked(uport);
-
-	if (uart_circ_chars_pending(tx_buf) < WAKEUP_CHARS)
-		uart_write_wakeup(uport);
-
 	if (msm_uport->tx.flush == FLUSH_STOP) {
 		msm_uport->tx.flush = FLUSH_SHUTDOWN;
 		wake_up(&msm_uport->tx.wait);
 		spin_unlock_irqrestore(&(msm_uport->uport.lock), flags);
 		return;
 	}
+
+	msm_uport->imr_reg |= UARTDM_ISR_TX_READY_BMSK;
+	msm_hs_write(&(msm_uport->uport), UART_DM_IMR, msm_uport->imr_reg);
+	/* Calling clk API. Hence mb() requires. */
+	mb();
 
 	spin_unlock_irqrestore(&(msm_uport->uport.lock), flags);
 	MSM_HS_DBG("In %s()\n", __func__);
@@ -1661,10 +1853,42 @@ static void msm_hs_sps_rx_callback(struct sps_event_notify *notify)
 	if (msm_uport->rx.flush == FLUSH_NONE) {
 		spin_lock_irqsave(&uport->lock, flags);
 		msm_uport->rx_count_callback = notify->data.transfer.iovec.size;
-		msm_uport->rx.rx_cmd_exec = true;
 		spin_unlock_irqrestore(&uport->lock, flags);
 		tasklet_schedule(&msm_uport->rx.tlet);
 	}
+}
+
+/*
+ * This routine is called when we are done with a DMA transfer or the
+ * a flush has been sent to the data mover driver.
+ *
+ * This routine is registered with Data mover when we set up a Data Mover
+ *  transfer. It is called from Data mover ISR when the DMA transfer is done.
+ */
+static void msm_hs_dmov_rx_callback(struct msm_dmov_cmd *cmd_ptr,
+					unsigned int result,
+					struct msm_dmov_errdata *err)
+{
+	struct msm_hs_port *msm_uport;
+	struct uart_port *uport;
+	unsigned long flags;
+
+	msm_uport = container_of(cmd_ptr, struct msm_hs_port, rx.xfer);
+	uport = &(msm_uport->uport);
+
+	MSM_HS_DBG("%s(): called result:%x\n", __func__, result);
+	if (!(result & DMOV_RSLT_ERROR)) {
+		if (result & DMOV_RSLT_FLUSH) {
+			if (msm_uport->rx_discard_flush_issued) {
+				spin_lock_irqsave(&uport->lock, flags);
+				msm_uport->rx_discard_flush_issued = false;
+				spin_unlock_irqrestore(&uport->lock, flags);
+				wake_up(&msm_uport->rx.wait);
+			}
+		}
+	}
+
+	tasklet_schedule(&msm_uport->rx.tlet);
 }
 
 /*
@@ -1700,11 +1924,9 @@ void msm_hs_set_mctrl_locked(struct uart_port *uport,
 	unsigned int data;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 
-	if (msm_uport->clk_state != MSM_HS_CLK_ON) {
-		MSM_HS_WARN("%s:Failed.Clocks are OFF\n", __func__);
-		printk(KERN_INFO "(msm_serial_hs) msm_hs_set_mctrl_locked.Clocks are OFF\n");
+	if (msm_uport->clk_state <= MSM_HS_CLK_OFF)
 		return;
-	}
+
 	/* RTS is active low */
 	set_rts = TIOCM_RTS & mctrl ? 0 : 1;
 
@@ -1728,12 +1950,15 @@ void msm_hs_set_mctrl(struct uart_port *uport,
 {
 	unsigned long flags;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
-	if (msm_uport->clk_state == MSM_HS_CLK_PORT_OFF) {
-		MSM_HS_ERR("%s:UART port is closed\n", __func__);
-		return ;
+	int ret;
+
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		return;
 	}
 
-	msm_hs_clock_vote(msm_uport);
 	spin_lock_irqsave(&uport->lock, flags);
 	msm_hs_set_mctrl_locked(uport, mctrl);
 	spin_unlock_irqrestore(&uport->lock, flags);
@@ -1746,16 +1971,22 @@ static void msm_hs_enable_ms_locked(struct uart_port *uport)
 {
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 
-	if (msm_uport->clk_state != MSM_HS_CLK_ON) {
-		MSM_HS_WARN("%s:Failed.Clocks are OFF\n", __func__);
+	if (msm_uport->clk_state <= MSM_HS_CLK_OFF)
 		return;
-	}
 
 	/* Enable DELTA_CTS Interrupt */
 	msm_uport->imr_reg |= UARTDM_ISR_DELTA_CTS_BMSK;
 	msm_hs_write(uport, UART_DM_IMR, msm_uport->imr_reg);
 	mb();
 
+}
+
+static void msm_hs_flush_buffer(struct uart_port *uport)
+{
+	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
+
+	if (msm_uport->tx.dma_in_flight)
+		msm_uport->tty_flush_receive = true;
 }
 
 /*
@@ -1768,9 +1999,12 @@ static void msm_hs_break_ctl(struct uart_port *uport, int ctl)
 {
 	unsigned long flags;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
+	int ret;
 
-	if (msm_uport->clk_state != MSM_HS_CLK_ON) {
-		MSM_HS_WARN("%s: Failed.Clocks are OFF\n", __func__);
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
 		return;
 	}
 
@@ -1778,24 +2012,35 @@ static void msm_hs_break_ctl(struct uart_port *uport, int ctl)
 	msm_hs_write(uport, UART_DM_CR, ctl ? START_BREAK : STOP_BREAK);
 	mb();
 	spin_unlock_irqrestore(&uport->lock, flags);
+
+	msm_hs_clock_unvote(msm_uport);
 }
 
 static void msm_hs_config_port(struct uart_port *uport, int cfg_flags)
 {
-	if (cfg_flags & UART_CONFIG_TYPE)
-		uport->type = PORT_MSM;
+	unsigned long flags;
+	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 
+	if (cfg_flags & UART_CONFIG_TYPE) {
+		uport->type = PORT_MSM;
+		msm_hs_request_port(uport);
+	}
+
+	if (is_gsbi_uart(msm_uport)) {
+		if (msm_uport->pclk)
+			clk_prepare_enable(msm_uport->pclk);
+		spin_lock_irqsave(&uport->lock, flags);
+		iowrite32(GSBI_PROTOCOL_UART, msm_uport->mapped_gsbi +
+			  GSBI_CONTROL_ADDR);
+		spin_unlock_irqrestore(&uport->lock, flags);
+		if (msm_uport->pclk)
+			clk_disable_unprepare(msm_uport->pclk);
+	}
 }
 
 /*  Handle CTS changes (Called from interrupt handler) */
 static void msm_hs_handle_delta_cts_locked(struct uart_port *uport)
 {
-	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
-
-	if (msm_uport->clk_state != MSM_HS_CLK_ON) {
-		MSM_HS_WARN("%s: Failed.Clocks are OFF\n", __func__);
-		return;
-	}
 	/* clear interrupt */
 	msm_hs_write(uport, UART_DM_CR, RESET_CTS);
 	/* Calling CLOCK API. Hence mb() requires here. */
@@ -1815,99 +2060,99 @@ static int msm_hs_check_clock_off(struct uart_port *uport)
 {
 	unsigned long sr_status;
 	unsigned long flags;
-#ifdef CONFIG_MSM_BT_POWER
-	unsigned int data;
-#endif
+	int ret;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
 	struct circ_buf *tx_buf = &uport->state->xmit;
-	struct platform_device *pdev = to_platform_device(uport->dev);
 
 	mutex_lock(&msm_uport->clk_mutex);
 	spin_lock_irqsave(&uport->lock, flags);
 
-	if (msm_uport->clk_state == MSM_HS_CLK_OFF) {
-		spin_unlock_irqrestore(&uport->lock, flags);
-		mutex_unlock(&msm_uport->clk_mutex);
-		MSM_HS_INFO("%s: Clocks Off Successfully\n", __func__);
-		return 1;
-	}
-	MSM_HS_DBG("In %s:\n", __func__);
 	/* Cancel if tx tty buffer is not empty, dma is in flight,
-	 * or tx fifo is not empty
-	 */
+	 * or tx fifo is not empty */
 	if (msm_uport->clk_state != MSM_HS_CLK_REQUEST_OFF ||
 	    !uart_circ_empty(tx_buf) || msm_uport->tx.dma_in_flight ||
 	    msm_uport->imr_reg & UARTDM_ISR_TXLEV_BMSK) {
-#ifdef CONFIG_MSM_BT_POWER
-		if (msm_uport->clk_state == MSM_HS_CLK_REQUEST_OFF) {
-			msm_uport->clk_state = MSM_HS_CLK_ON;
-			/* Pulling RFR line high */
-			msm_hs_write(uport, UART_DM_CR, RFR_LOW);
-			/* Enable auto RFR */
-			data = msm_hs_read(uport, UART_DM_MR1);
-			data |= UARTDM_MR1_RX_RDY_CTL_BMSK;
-			msm_hs_write(uport, UART_DM_MR1, data);
-			mb();
-		}
-#endif
 		spin_unlock_irqrestore(&uport->lock, flags);
 		mutex_unlock(&msm_uport->clk_mutex);
-		MSM_HS_DBG("%s(): clkstate %d", __func__, msm_uport->clk_state);
 		return -1;
 	}
 
-	/* Make sure the uart is finished with the last byte,
-	 * use BFamily Register
-	 */
-	sr_status = msm_hs_read(uport, UART_DM_SR);
+	/* Make sure the uart is finished with the last byte */
+	sr_status = msm_hs_read(uport, UARTDM_SR);
 	if (!(sr_status & UARTDM_SR_TXEMT_BMSK)) {
 		spin_unlock_irqrestore(&uport->lock, flags);
 		mutex_unlock(&msm_uport->clk_mutex);
-		MSM_HS_DBG("%s(): SR TXEMT fail %lx", __func__, sr_status);
 		return 0;  /* retry */
 	}
 
-	if (msm_uport->rx.flush != FLUSH_SHUTDOWN) {
-		if (msm_uport->rx.flush == FLUSH_NONE)
-			msm_hs_stop_rx_locked(uport);
+	/* Make sure forced RXSTALE flush complete */
+	switch (msm_uport->clk_req_off_state) {
+	case CLK_REQ_OFF_START:
+		msm_uport->clk_req_off_state = CLK_REQ_OFF_RXSTALE_ISSUED;
 
-		MSM_HS_DBG("%s: rx.flush %d clk_state %d\n", __func__,
-			msm_uport->rx.flush, msm_uport->clk_state);
+		if (!is_blsp_uart(msm_uport)) {
+			msm_hs_write(uport, UART_DM_CR, FORCE_STALE_EVENT);
+			/*
+			* Before returning make sure that device writel
+			* completed. Hence mb() requires here.
+			*/
+			mb();
+		}
 		spin_unlock_irqrestore(&uport->lock, flags);
+		mutex_unlock(&msm_uport->clk_mutex);
+		return 0;  /* RXSTALE flush not complete - retry */
+	case CLK_REQ_OFF_RXSTALE_ISSUED:
+	case CLK_REQ_OFF_FLUSH_ISSUED:
+		spin_unlock_irqrestore(&uport->lock, flags);
+		if (is_blsp_uart(msm_uport)) {
+			msm_uport->clk_req_off_state =
+				CLK_REQ_OFF_RXSTALE_FLUSHED;
+		}
+		mutex_unlock(&msm_uport->clk_mutex);
+		return 0;  /* RXSTALE flush not complete - retry */
+	case CLK_REQ_OFF_RXSTALE_FLUSHED:
+		break;  /* continue */
+	}
+
+	if (msm_uport->rx.flush != FLUSH_SHUTDOWN) {
+		if (msm_uport->rx.flush == FLUSH_NONE) {
+			msm_hs_stop_rx_locked(uport);
+			if (!is_blsp_uart(msm_uport))
+				msm_uport->rx_discard_flush_issued = true;
+		}
+
+		spin_unlock_irqrestore(&uport->lock, flags);
+		if (msm_uport->rx_discard_flush_issued) {
+			MSM_HS_DBG("%s(): wainting for flush completion.\n",
+								__func__);
+			ret = wait_event_timeout(msm_uport->rx.wait,
+				msm_uport->rx_discard_flush_issued == false,
+				RX_FLUSH_COMPLETE_TIMEOUT);
+			if (!ret)
+				MSM_HS_ERR("%s(): Flush complete pending.\n",
+								__func__);
+		}
+
 		mutex_unlock(&msm_uport->clk_mutex);
 		return 0;  /* come back later to really clock off */
 	}
 
 	spin_unlock_irqrestore(&uport->lock, flags);
 
-#ifdef CONFIG_MSM_BT_POWER
-	/* Pulling RFR line high */
-	msm_hs_write(uport, UART_DM_CR, RFR_LOW);
-	/* Enable auto RFR */
-	data = msm_hs_read(uport, UART_DM_MR1);
-	data |= UARTDM_MR1_RX_RDY_CTL_BMSK;
-	msm_hs_write(uport, UART_DM_MR1, data);
-	mb();
-#endif
-
 	/* we really want to clock off */
-	mutex_unlock(&msm_uport->clk_mutex);
 	msm_hs_clock_unvote(msm_uport);
-	mutex_lock(&msm_uport->clk_mutex);
 
 	spin_lock_irqsave(&uport->lock, flags);
 	if (use_low_power_wakeup(msm_uport)) {
 		msm_uport->wakeup.ignore = 1;
 		enable_irq(msm_uport->wakeup.irq);
 	}
-
-	if (pdev->id == 0)
-		printk(KERN_INFO "(msm_serial_hs) msm_hs_check_clock_off - dma wake unlock\n");
-
 	wake_unlock(&msm_uport->dma_wake_lock);
 
 	spin_unlock_irqrestore(&uport->lock, flags);
 
+	/* Reset PNOC Bus Scaling */
+	msm_hs_bus_voting(msm_uport, BUS_RESET);
 	mutex_unlock(&msm_uport->clk_mutex);
 
 	return 1;
@@ -1918,20 +2163,11 @@ static void hsuart_clock_off_work(struct work_struct *w)
 	struct msm_hs_port *msm_uport = container_of(w, struct msm_hs_port,
 							clock_off_w);
 	struct uart_port *uport = &msm_uport->uport;
-	struct platform_device *pdev = to_platform_device(uport->dev);
 
-	int check_clk_off = msm_hs_check_clock_off(uport);
-
-	if (!check_clk_off) {
+	if (!msm_hs_check_clock_off(uport)) {
 		hrtimer_start(&msm_uport->clk_off_timer,
 				msm_uport->clk_off_delay,
 				HRTIMER_MODE_REL);
-	} else if (check_clk_off == -1) {
-		if (pdev->id == 0)
-			printk(KERN_INFO "(msm_serial_hs) hsuart_clock_off_work WORKQUEUE - FIFO is not empty or in flight...\n");
-	} else {
-		if (pdev->id == 0)
-			printk(KERN_INFO "(msm_serial_hs) hsuart_clock_off_work WORKQUEUE - Maybe, clock is off-ed.\n");
 	}
 }
 
@@ -1979,6 +2215,16 @@ static irqreturn_t msm_hs_isr(int irq, void *dev)
 		 */
 		mb();
 		MSM_HS_DBG("%s:Stal Interrupt\n", __func__);
+
+		if (msm_uport->clk_req_off_state ==
+					CLK_REQ_OFF_RXSTALE_ISSUED)
+			msm_uport->clk_req_off_state =
+					CLK_REQ_OFF_FLUSH_ISSUED;
+
+		if (!is_blsp_uart(msm_uport) && (rx->flush == FLUSH_NONE)) {
+			rx->flush = FLUSH_DATA_READY;
+			msm_dmov_flush(msm_uport->dma_rx_channel, 1);
+		}
 	}
 	/* tx ready interrupt */
 	if (isr_status & UARTDM_ISR_TX_READY_BMSK) {
@@ -1998,11 +2244,12 @@ static irqreturn_t msm_hs_isr(int irq, void *dev)
 		/* Complete DMA TX transactions and submit new transactions */
 
 		/* Do not update tx_buf.tail if uart_flush_buffer already
-		 * called in serial core
-		 */
-		if (!uart_circ_empty(tx_buf))
+						called in serial core */
+		if (!msm_uport->tty_flush_receive)
 			tx_buf->tail = (tx_buf->tail +
 					tx->tx_count) & ~UART_XMIT_SIZE;
+		else
+			msm_uport->tty_flush_receive = false;
 
 		tx->dma_in_flight = 0;
 
@@ -2017,7 +2264,6 @@ static irqreturn_t msm_hs_isr(int irq, void *dev)
 		/* TX FIFO is empty */
 		msm_uport->imr_reg &= ~UARTDM_ISR_TXLEV_BMSK;
 		msm_hs_write(uport, UART_DM_IMR, msm_uport->imr_reg);
-		MSM_HS_DBG("%s: TXLEV Interrupt\n", __func__);
 		/*
 		 * Complete device write before starting clock_off request.
 		 * Hence mb() requires here.
@@ -2047,8 +2293,7 @@ struct uart_port *msm_hs_get_uart_port(int port_index)
 
 	/* The uart_driver structure stores the states in an array.
 	 * Thus the corresponding offset from the drv->state returns
-	 * the state for the uart_port that is requested
-	 */
+	 * the state for the uart_port that is requested */
 	if (port_index == state->uart_port->line)
 		return state->uart_port;
 
@@ -2068,28 +2313,17 @@ static struct msm_hs_port *msm_hs_get_hs_port(int port_index)
 void msm_hs_request_clock_off(struct uart_port *uport) {
 	unsigned long flags;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
-	int data;
 
-	if (msm_uport->clk_state == MSM_HS_CLK_PORT_OFF) {
-		MSM_HS_ERR("%s:UART port is closed\n", __func__);
-		return ;
-	}
 	spin_lock_irqsave(&uport->lock, flags);
 	if (msm_uport->clk_state == MSM_HS_CLK_ON) {
 		msm_uport->clk_state = MSM_HS_CLK_REQUEST_OFF;
-		data = msm_hs_read(uport, UART_DM_MR1);
-		/*disable auto ready-for-receiving */
-		data &= ~UARTDM_MR1_RX_RDY_CTL_BMSK;
-		msm_hs_write(uport, UART_DM_MR1, data);
-		mb();
-		/* set RFR_N to high */
-		msm_hs_write(uport, UART_DM_CR, RFR_HIGH);
-
-		data = msm_hs_read(uport, UART_DM_SR);
-		MSM_HS_DBG("%s(): TXEMT, queuing clock off work\n",
-			__func__);
-		queue_work(msm_uport->hsuart_wq, &msm_uport->clock_off_w);
-
+		msm_uport->clk_req_off_state = CLK_REQ_OFF_START;
+		msm_uport->imr_reg |= UARTDM_ISR_TXLEV_BMSK;
+		msm_hs_write(uport, UART_DM_IMR, msm_uport->imr_reg);
+		/*
+		 * Complete device write before retuning back.
+		 * Hence mb() requires here.
+		 */
 		mb();
 	}
 	spin_unlock_irqrestore(&uport->lock, flags);
@@ -2102,43 +2336,20 @@ void msm_hs_request_clock_on(struct uart_port *uport)
 	unsigned long flags;
 	unsigned int data;
 	int ret = 0;
-	struct platform_device *pdev = to_platform_device(uport->dev);
-
-	if (msm_uport->clk_state == MSM_HS_CLK_PORT_OFF) {
-		MSM_HS_ERR("%s:UART port is closed\n", __func__);
-		return ;
-	}
 
 	mutex_lock(&msm_uport->clk_mutex);
 	spin_lock_irqsave(&uport->lock, flags);
 
-#ifdef CONFIG_MSM_BT_POWER
-	if (msm_uport->clk_state == MSM_HS_CLK_REQUEST_OFF) {
-		/* Pulling RFR line high */
-		msm_hs_write(uport, UART_DM_CR, RFR_LOW);
-		/* Enable auto RFR */
-		data = msm_hs_read(uport, UART_DM_MR1);
-		data |= UARTDM_MR1_RX_RDY_CTL_BMSK;
-		msm_hs_write(uport, UART_DM_MR1, data);
-		mb();
-	}
-#endif
-
 	switch (msm_uport->clk_state) {
 	case MSM_HS_CLK_OFF:
-		if (pdev->id == 0)
-			printk(KERN_INFO "(msm_serial_hs) msm_hs_check_clock_on - dma wake lock\n");
-
 		wake_lock(&msm_uport->dma_wake_lock);
 		if (use_low_power_wakeup(msm_uport))
 			disable_irq_nosync(msm_uport->wakeup.irq);
 		spin_unlock_irqrestore(&uport->lock, flags);
 
-		mutex_unlock(&msm_uport->clk_mutex);
 		ret = msm_hs_clock_vote(msm_uport);
-		mutex_lock(&msm_uport->clk_mutex);
 		if (ret) {
-			MSM_HS_INFO("Clock ON Failure"
+			dev_err(uport->dev, "Clock ON Failure"
 			"For UART CLK Stalling HSUART\n");
 			break;
 		}
@@ -2146,55 +2357,37 @@ void msm_hs_request_clock_on(struct uart_port *uport)
 		spin_lock_irqsave(&uport->lock, flags);
 		/* else fall-through */
 	case MSM_HS_CLK_REQUEST_OFF:
-		hrtimer_cancel(&msm_uport->clk_off_timer);
-		if (msm_uport->rx.flush == FLUSH_STOP) {
-			spin_unlock_irqrestore(&uport->lock, flags);
-			MSM_HS_DBG("%s:Calling wait forxcompletion\n",
-					__func__);
-			mutex_unlock(&msm_uport->clk_mutex);
-			ret = wait_event_timeout(msm_uport->bam_disconnect_wait,
-				msm_uport->rx.flush == FLUSH_SHUTDOWN, 300);
-			mutex_lock(&msm_uport->clk_mutex);
-			if (!ret)
-				MSM_HS_ERR("BAM Disconnect not happened\n");
-			spin_lock_irqsave(&uport->lock, flags);
-			MSM_HS_DBG("%s:DONE wait for completion\n", __func__);
-		}
-		MSM_HS_DBG("%s:clock state %d\n\n", __func__,
-				msm_uport->clk_state);
-		if (msm_uport->clk_state == MSM_HS_CLK_REQUEST_OFF)
-				msm_uport->clk_state = MSM_HS_CLK_ON;
 		if (msm_uport->rx.flush == FLUSH_STOP ||
 		    msm_uport->rx.flush == FLUSH_SHUTDOWN) {
 			msm_hs_write(uport, UART_DM_CR, RESET_RX);
 			data = msm_hs_read(uport, UART_DM_DMEN);
-			data |= UARTDM_RX_BAM_ENABLE_BMSK;
+			if (is_blsp_uart(msm_uport))
+				data |= UARTDM_RX_BAM_ENABLE_BMSK;
+			else
+				data |= UARTDM_RX_DM_EN_BMSK;
 			msm_hs_write(uport, UART_DM_DMEN, data);
 			/* Complete above device write. Hence mb() here. */
 			mb();
 		}
-
-		MSM_HS_DBG("%s: rx.flush %d\n", __func__, msm_uport->rx.flush);
+		hrtimer_try_to_cancel(&msm_uport->clk_off_timer);
 		if (msm_uport->rx.flush == FLUSH_SHUTDOWN) {
-			spin_unlock_irqrestore(&uport->lock, flags);
-			msm_hs_spsconnect_rx(uport);
-			spin_lock_irqsave(&uport->lock, flags);
+			if (is_blsp_uart(msm_uport)) {
+				spin_unlock_irqrestore(&uport->lock, flags);
+				msm_hs_spsconnect_rx(uport);
+				spin_lock_irqsave(&uport->lock, flags);
+			}
 			msm_hs_start_rx_locked(uport);
 		}
 		if (msm_uport->rx.flush == FLUSH_STOP)
 			msm_uport->rx.flush = FLUSH_IGNORE;
-
+		msm_uport->clk_state = MSM_HS_CLK_ON;
 		break;
 	case MSM_HS_CLK_ON:
 		break;
 	case MSM_HS_CLK_PORT_OFF:
-		MSM_HS_ERR("%s:Clock ON failed;UART Port is Closed\n",
-								__func__);
 		break;
 	}
 
-	MSM_HS_INFO("%s:Clock ON Successful\n", __func__);
-	dump_uart_hs_registers(msm_uport);
 	spin_unlock_irqrestore(&uport->lock, flags);
 	mutex_unlock(&msm_uport->clk_mutex);
 }
@@ -2220,8 +2413,7 @@ static irqreturn_t msm_hs_wakeup_isr(int irq, void *dev)
 	spin_lock_irqsave(&uport->lock, flags);
 	if (msm_uport->clk_state == MSM_HS_CLK_OFF)  {
 		/* ignore the first irq - it is a pending irq that occured
-		 * before enable_irq()
-		 */
+		 * before enable_irq() */
 		if (msm_uport->wakeup.ignore)
 			msm_uport->wakeup.ignore = 0;
 		else
@@ -2230,8 +2422,7 @@ static irqreturn_t msm_hs_wakeup_isr(int irq, void *dev)
 
 	if (wakeup) {
 		/* the uart was clocked off during an rx, wake up and
-		 * optionally inject char into tty rx
-		 */
+		 * optionally inject char into tty rx */
 		spin_unlock_irqrestore(&uport->lock, flags);
 		msm_hs_request_clock_on(uport);
 		spin_lock_irqsave(&uport->lock, flags);
@@ -2240,8 +2431,6 @@ static irqreturn_t msm_hs_wakeup_isr(int irq, void *dev)
 			tty_insert_flip_char(tty,
 					     msm_uport->wakeup.rx_to_inject,
 					     TTY_NORMAL);
-			MSM_HS_DBG("%s(): Inject 0x%x", __func__,
-				msm_uport->wakeup.rx_to_inject);
 		}
 	}
 
@@ -2276,9 +2465,8 @@ static void msm_hs_unconfig_uart_gpios(struct uart_port *uport)
 			gpio_free(pdata->uart_cts_gpio);
 		if (gpio_is_valid(pdata->uart_rfr_gpio))
 			gpio_free(pdata->uart_rfr_gpio);
-	} else {
+	} else
 		MSM_HS_ERR("Error:Pdata is NULL.\n");
-	}
 }
 
 /**
@@ -2359,12 +2547,14 @@ static int msm_hs_startup(struct uart_port *uport)
 	unsigned long flags;
 	unsigned int data;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
+	struct platform_device *pdev = to_platform_device(uport->dev);
+	const struct msm_serial_hs_platform_data *pdata =
+					pdev->dev.platform_data;
 	struct circ_buf *tx_buf = &uport->state->xmit;
 	struct msm_hs_tx *tx = &msm_uport->tx;
 	struct msm_hs_rx *rx = &msm_uport->rx;
 	struct sps_pipe *sps_pipe_handle_tx = tx->cons.pipe_handle;
 	struct sps_pipe *sps_pipe_handle_rx = rx->prod.pipe_handle;
-	struct platform_device *pdev = to_platform_device(uport->dev);
 
 	rfr_level = uport->fifosize;
 	if (rfr_level > 16)
@@ -2372,9 +2562,6 @@ static int msm_hs_startup(struct uart_port *uport)
 
 	tx->dma_base = dma_map_single(uport->dev, tx_buf->buf, UART_XMIT_SIZE,
 				      DMA_TO_DEVICE);
-
-	if (pdev->id == 0)
-		printk(KERN_INFO "(msm_serial_hs) msm_hs_startup - dma wake lock\n");
 
 	wake_lock(&msm_uport->dma_wake_lock);
 	/* turn on uart clk */
@@ -2385,31 +2572,34 @@ static int msm_hs_startup(struct uart_port *uport)
 		return ret;
 	}
 
-	ret = msm_hs_config_uart_gpios(uport);
-	if (ret) {
-		MSM_HS_ERR("Uart GPIO request failed\n");
-		goto deinit_uart_clk;
+	if (is_blsp_uart(msm_uport)) {
+		ret = msm_hs_config_uart_gpios(uport);
+		if (ret) {
+			MSM_HS_ERR("Uart GPIO request failed\n");
+			goto deinit_uart_clk;
+		}
+	} else {
+		if (pdata && pdata->gpio_config)
+			if (unlikely(pdata->gpio_config(1)))
+				dev_err(uport->dev, "Cannot configure gpios\n");
 	}
 
 	/* SPS Connect for BAM endpoints */
-	/* SPS connect for TX */
-	ret = msm_hs_spsconnect_tx(uport);
-	if (ret) {
-		MSM_HS_ERR("msm_serial_hs: SPS connect failed for TX");
-		goto unconfig_uart_gpios;
-	}
+	if (is_blsp_uart(msm_uport)) {
+		/* SPS connect for TX */
+		ret = msm_hs_spsconnect_tx(uport);
+		if (ret) {
+			MSM_HS_ERR("msm_serial_hs: SPS connect failed for TX");
+			goto unconfig_uart_gpios;
+		}
 
-	/* SPS connect for RX */
-	ret = msm_hs_spsconnect_rx(uport);
-	if (ret) {
-		MSM_HS_ERR("msm_serial_hs: SPS connect failed for RX");
-		goto sps_disconnect_tx;
+		/* SPS connect for RX */
+		ret = msm_hs_spsconnect_rx(uport);
+		if (ret) {
+			MSM_HS_ERR("msm_serial_hs: SPS connect failed for RX");
+			goto sps_disconnect_tx;
+		}
 	}
-
-	data = (UARTDM_BCR_TX_BREAK_DISABLE | UARTDM_BCR_STALE_IRQ_EMPTY |
-		UARTDM_BCR_RX_DMRX_LOW_EN | UARTDM_BCR_RX_STAL_IRQ_DMRX_EQL |
-		UARTDM_BCR_RX_DMRX_1BYTE_RES_EN);
-	msm_hs_write(uport, UART_DM_BCR, data);
 
 	/* Set auto RFR Level */
 	data = msm_hs_read(uport, UART_DM_MR1);
@@ -2426,8 +2616,13 @@ static int msm_hs_startup(struct uart_port *uport)
 		msm_hs_write(uport, UART_DM_IPR, data);
 	}
 
-	/* Enable BAM mode */
-	data  = UARTDM_TX_BAM_ENABLE_BMSK | UARTDM_RX_BAM_ENABLE_BMSK;
+	if (is_blsp_uart(msm_uport)) {
+		/* Enable BAM mode */
+		data  = UARTDM_TX_BAM_ENABLE_BMSK | UARTDM_RX_BAM_ENABLE_BMSK;
+	} else {
+		/* Enable Data Mover Mode */
+		data = UARTDM_TX_DM_EN_BMSK | UARTDM_RX_DM_EN_BMSK;
+	}
 	msm_hs_write(uport, UART_DM_DMEN, data);
 
 	/* Reset TX */
@@ -2447,13 +2642,29 @@ static int msm_hs_startup(struct uart_port *uport)
 	/* Initialize the tx */
 	tx->tx_ready_int_en = 0;
 	tx->dma_in_flight = 0;
-	rx->rx_cmd_exec = false;
+
+	if (!is_blsp_uart(msm_uport)) {
+		tx->xfer.complete_func = msm_hs_dmov_tx_callback;
+
+		tx->command_ptr->cmd = CMD_LC |
+			CMD_DST_CRCI(msm_uport->dma_tx_crci) | CMD_MODE_BOX;
+
+		tx->command_ptr->src_dst_len = (MSM_UARTDM_BURST_SIZE << 16)
+					   | (MSM_UARTDM_BURST_SIZE);
+
+		tx->command_ptr->row_offset = (MSM_UARTDM_BURST_SIZE << 16);
+
+		tx->command_ptr->dst_row_addr =
+			msm_uport->uport.mapbase + UARTDM_TF_ADDR;
+
+		msm_uport->imr_reg |= UARTDM_ISR_RXSTALE_BMSK;
+	}
 
 	/* Enable reading the current CTS, no harm even if CTS is ignored */
 	msm_uport->imr_reg |= UARTDM_ISR_CURRENT_CTS_BMSK;
 
 	/* TXLEV on empty TX fifo */
-	msm_hs_write(uport, UART_DM_TFWR, 4);
+	msm_hs_write(uport, UART_DM_TFWR, 0);
 	/*
 	 * Complete all device write related configuration before
 	 * queuing RX request. Hence mb() requires here.
@@ -2478,20 +2689,31 @@ static int msm_hs_startup(struct uart_port *uport)
 
 		ret = request_threaded_irq(msm_uport->wakeup.irq, NULL,
 					msm_hs_wakeup_isr,
-					IRQF_TRIGGER_FALLING,
+					IRQF_TRIGGER_FALLING | IRQF_ONESHOT,
 					"msm_hs_wakeup", msm_uport);
 
 		if (unlikely(ret)) {
-			MSM_HS_ERR("%s():Err getting uart wakeup_irq\n", __func__);
+			MSM_HS_ERR("%s():Err getting uart wakeup_irq\n",
+				  __func__);
 			goto free_uart_irq;
 		}
 		disable_irq(msm_uport->wakeup.irq);
 	}
+
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		goto free_uart_irq;
+	}
+
 	spin_lock_irqsave(&uport->lock, flags);
 
 	msm_hs_start_rx_locked(uport);
 
 	spin_unlock_irqrestore(&uport->lock, flags);
+
+	msm_hs_clock_unvote(msm_uport);
 
 	pm_runtime_enable(uport->dev);
 
@@ -2503,17 +2725,16 @@ free_wake_irq:
 	if (use_low_power_wakeup(msm_uport))
 		irq_set_irq_wake(msm_uport->wakeup.irq, 0);
 sps_disconnect_rx:
-	sps_disconnect(sps_pipe_handle_rx);
+	if (is_blsp_uart(msm_uport))
+		sps_disconnect(sps_pipe_handle_rx);
 sps_disconnect_tx:
-	sps_disconnect(sps_pipe_handle_tx);
+	if (is_blsp_uart(msm_uport))
+		sps_disconnect(sps_pipe_handle_tx);
 unconfig_uart_gpios:
-	msm_hs_unconfig_uart_gpios(uport);
+	if (is_blsp_uart(msm_uport))
+		msm_hs_unconfig_uart_gpios(uport);
 deinit_uart_clk:
 	msm_hs_clock_unvote(msm_uport);
-
-	if (pdev->id == 0)
-		printk(KERN_INFO "(msm_serial_hs) msm_hs_startup deinit clk - dma wake unlock\n");
-
 	wake_unlock(&msm_uport->dma_wake_lock);
 
 	return ret;
@@ -2529,7 +2750,6 @@ static int uartdm_init_port(struct uart_port *uport)
 
 	init_waitqueue_head(&rx->wait);
 	init_waitqueue_head(&tx->wait);
-	init_waitqueue_head(&msm_uport->bam_disconnect_wait);
 	wake_lock_init(&rx->wake_lock, WAKE_LOCK_SUSPEND, "msm_serial_hs_rx");
 	wake_lock_init(&msm_uport->dma_wake_lock, WAKE_LOCK_SUSPEND,
 		       "msm_serial_hs_dma");
@@ -2544,7 +2764,7 @@ static int uartdm_init_port(struct uart_port *uport)
 	if (!rx->pool) {
 		MSM_HS_ERR("%s(): cannot allocate rx_buffer_pool", __func__);
 		ret = -ENOMEM;
-		goto exit_tasklet_init;
+		goto exit_tasket_init;
 	}
 
 	rx->buffer = dma_pool_alloc(rx->pool, GFP_KERNEL, &rx->rbuffer);
@@ -2555,15 +2775,99 @@ static int uartdm_init_port(struct uart_port *uport)
 	}
 
 	/* Set up Uart Receive */
-	msm_hs_write(uport, UART_DM_RFWR, 32);
+	if (is_blsp_uart(msm_uport))
+		msm_hs_write(uport, UART_DM_RFWR, 32);
+	else
+		msm_hs_write(uport, UART_DM_RFWR, 0);
 
 	INIT_DELAYED_WORK(&rx->flip_insert_work, flip_insert_work);
 
+	if (is_blsp_uart(msm_uport))
+		return ret;
+
+	/* Allocate the command pointer. Needs to be 64 bit aligned */
+	tx->command_ptr = kmalloc(sizeof(dmov_box), GFP_KERNEL | __GFP_DMA);
+	if (!tx->command_ptr) {
+		return -ENOMEM;
+		goto free_rx_buffer;
+	}
+
+	tx->command_ptr_ptr = kmalloc(sizeof(u32), GFP_KERNEL | __GFP_DMA);
+	if (!tx->command_ptr_ptr) {
+		ret = -ENOMEM;
+		goto free_tx_command_ptr;
+	}
+
+	tx->mapped_cmd_ptr = dma_map_single(uport->dev, tx->command_ptr,
+					sizeof(dmov_box), DMA_TO_DEVICE);
+	tx->mapped_cmd_ptr_ptr = dma_map_single(uport->dev,
+						tx->command_ptr_ptr,
+						sizeof(u32), DMA_TO_DEVICE);
+	tx->xfer.cmdptr = DMOV_CMD_ADDR(tx->mapped_cmd_ptr_ptr);
+
+	/* Allocate the command pointer. Needs to be 64 bit aligned */
+	rx->command_ptr = kmalloc(sizeof(dmov_box), GFP_KERNEL | __GFP_DMA);
+	if (!rx->command_ptr) {
+		MSM_HS_ERR("%s(): cannot allocate rx->command_ptr", __func__);
+		ret = -ENOMEM;
+		goto free_tx_command_ptr_ptr;
+	}
+
+	rx->command_ptr_ptr = kmalloc(sizeof(u32), GFP_KERNEL | __GFP_DMA);
+	if (!rx->command_ptr_ptr) {
+		MSM_HS_ERR("%s(): cannot allocate rx->command_ptr_ptr",
+			  __func__);
+		ret = -ENOMEM;
+		goto free_rx_command_ptr;
+	}
+
+	rx->command_ptr->num_rows = ((UARTDM_RX_BUF_SIZE >> 4) << 16) |
+					 (UARTDM_RX_BUF_SIZE >> 4);
+
+	rx->command_ptr->dst_row_addr = rx->rbuffer;
+
+	rx->xfer.complete_func = msm_hs_dmov_rx_callback;
+
+	rx->command_ptr->cmd = CMD_LC |
+	    CMD_SRC_CRCI(msm_uport->dma_rx_crci) | CMD_MODE_BOX;
+
+	rx->command_ptr->src_dst_len = (MSM_UARTDM_BURST_SIZE << 16)
+					   | (MSM_UARTDM_BURST_SIZE);
+	rx->command_ptr->row_offset =  MSM_UARTDM_BURST_SIZE;
+	rx->command_ptr->src_row_addr = uport->mapbase + UARTDM_RF_ADDR;
+
+	rx->mapped_cmd_ptr = dma_map_single(uport->dev, rx->command_ptr,
+					    sizeof(dmov_box), DMA_TO_DEVICE);
+
+	*rx->command_ptr_ptr = CMD_PTR_LP | DMOV_CMD_ADDR(rx->mapped_cmd_ptr);
+
+	rx->cmdptr_dmaaddr = dma_map_single(uport->dev, rx->command_ptr_ptr,
+					    sizeof(u32), DMA_TO_DEVICE);
+	rx->xfer.cmdptr = DMOV_CMD_ADDR(rx->cmdptr_dmaaddr);
+
 	return ret;
+
+free_rx_command_ptr:
+	kfree(rx->command_ptr);
+
+free_tx_command_ptr_ptr:
+	kfree(msm_uport->tx.command_ptr_ptr);
+	dma_unmap_single(uport->dev, msm_uport->tx.mapped_cmd_ptr_ptr,
+			sizeof(u32), DMA_TO_DEVICE);
+	dma_unmap_single(uport->dev, msm_uport->tx.mapped_cmd_ptr,
+			sizeof(dmov_box), DMA_TO_DEVICE);
+
+free_tx_command_ptr:
+	kfree(msm_uport->tx.command_ptr);
+
+free_rx_buffer:
+	dma_pool_free(msm_uport->rx.pool, msm_uport->rx.buffer,
+			msm_uport->rx.rbuffer);
+
 free_pool:
 	dma_pool_destroy(msm_uport->rx.pool);
 
-exit_tasklet_init:
+exit_tasket_init:
 	wake_lock_destroy(&msm_uport->rx.wake_lock);
 	wake_lock_destroy(&msm_uport->dma_wake_lock);
 	tasklet_kill(&msm_uport->tx.tlet);
@@ -2584,7 +2888,6 @@ struct msm_serial_hs_platform_data
 		return ERR_PTR(-ENOMEM);
 	}
 
-	pdev->id = of_alias_get_id(pdev->dev.of_node, "uart");
 	/* UART TX GPIO */
 	pdata->uart_tx_gpio = of_get_named_gpio(node,
 					"qcom,tx-gpio", 0);
@@ -2608,9 +2911,6 @@ struct msm_serial_hs_platform_data
 					"qcom,rfr-gpio", 0);
 	if (pdata->uart_rfr_gpio < 0)
 		MSM_HS_DBG("uart_rfr_gpio is not available\n");
-
-	pdata->no_suspend_delay = of_property_read_bool(node,
-				"qcom,no-suspend-delay");
 
 	pdata->inject_rx_on_wakeup = of_property_read_bool(node,
 				"qcom,inject-rx-on-wakeup");
@@ -2707,8 +3007,8 @@ static int msm_hs_sps_init_ep_conn(struct msm_hs_port *msm_uport,
 	/* Allocate endpoint context */
 	sps_pipe_handle = sps_alloc_endpoint();
 	if (!sps_pipe_handle) {
-		MSM_HS_ERR("%s(): sps_alloc_endpoint() failed!!\n"
-			"is_producer=%d", __func__, is_producer);
+		MSM_HS_ERR("msm_serial_hs: sps_alloc_endpoint() failed!!\n"
+			"is_producer=%d", is_producer);
 		rc = -ENOMEM;
 		goto out;
 	}
@@ -2716,8 +3016,8 @@ static int msm_hs_sps_init_ep_conn(struct msm_hs_port *msm_uport,
 	/* Get default connection configuration for an endpoint */
 	rc = sps_get_config(sps_pipe_handle, sps_config);
 	if (rc) {
-		MSM_HS_ERR("%s(): failed! pipe_handle=0x%p rc=%d",
-			__func__, sps_pipe_handle, rc);
+		MSM_HS_ERR("msm_serial_hs: sps_get_config() failed!!\n"
+		"pipe_handle=0x%x rc=%d", (u32)sps_pipe_handle, rc);
 		goto get_config_err;
 	}
 
@@ -2730,6 +3030,7 @@ static int msm_hs_sps_init_ep_conn(struct msm_hs_port *msm_uport,
 		sps_config->mode = SPS_MODE_SRC;
 		sps_config->src_pipe_index = msm_uport->bam_rx_ep_pipe_index;
 		sps_config->dest_pipe_index = 0;
+		sps_config->options = SPS_O_DESC_DONE;
 	} else {
 		/* For UART consumer transfer, source is system memory
 		where as destination is UART peripheral */
@@ -2738,9 +3039,9 @@ static int msm_hs_sps_init_ep_conn(struct msm_hs_port *msm_uport,
 		sps_config->mode = SPS_MODE_DEST;
 		sps_config->src_pipe_index = 0;
 		sps_config->dest_pipe_index = msm_uport->bam_tx_ep_pipe_index;
+		sps_config->options = SPS_O_EOT;
 	}
 
-	sps_config->options = SPS_O_EOT | SPS_O_DESC_DONE | SPS_O_AUTO_ENABLE;
 	sps_config->event_thresh = 0x10;
 
 	/* Allocate maximum descriptor fifo size */
@@ -2760,19 +3061,20 @@ static int msm_hs_sps_init_ep_conn(struct msm_hs_port *msm_uport,
 
 	if (is_producer) {
 		sps_event->callback = msm_hs_sps_rx_callback;
+		sps_event->options = SPS_O_DESC_DONE;
 	} else {
 		sps_event->callback = msm_hs_sps_tx_callback;
+		sps_event->options = SPS_O_EOT;
 	}
 
-	sps_event->options = SPS_O_DESC_DONE | SPS_O_EOT;
 	sps_event->user = (void *)msm_uport;
 
 	/* Now save the sps pipe handle */
 	ep->pipe_handle = sps_pipe_handle;
-	MSM_HS_DBG("msm_serial_hs: success !! %s: pipe_handle=0x%p\n"
-		"desc_fifo.phys_base=0x%pa\n",
+	pr_debug("msm_serial_hs: success !! %s: pipe_handle=0x%x\n"
+		"desc_fifo.phys_base=0x%llx\n",
 		is_producer ? "READ" : "WRITE",
-		sps_pipe_handle, &sps_config->desc.phys_base);
+		(u32) sps_pipe_handle, (u64) sps_config->desc.phys_base);
 	return 0;
 
 get_config_err:
@@ -2796,7 +3098,7 @@ static int msm_hs_sps_init(struct msm_hs_port *msm_uport)
 {
 	int rc = 0;
 	struct sps_bam_props bam = {0};
-	u32 bam_handle;
+	unsigned long bam_handle;
 
 	rc = sps_phy2h(msm_uport->bam_mem, &bam_handle);
 	if (rc || !bam_handle) {
@@ -2813,19 +3115,20 @@ static int msm_hs_sps_init(struct msm_hs_port *msm_uport)
 		bam.irq = (u32)msm_uport->bam_irq;
 		bam.manage = SPS_BAM_MGR_DEVICE_REMOTE;
 
-		MSM_HS_DBG("msm_serial_hs: bam physical base=0x%pa\n",
-							&bam.phys_addr);
-		MSM_HS_DBG("msm_serial_hs: bam virtual base=0x%p\n",
-							bam.virt_addr);
+		MSM_HS_DBG("msm_serial_hs: bam physical base=0x%x\n",
+							(u32)bam.phys_addr);
+		MSM_HS_DBG("msm_serial_hs: bam virtual base=0x%x\n",
+							(u32)bam.virt_addr);
 
 		/* Register UART Peripheral BAM device to SPS driver */
 		rc = sps_register_bam_device(&bam, &bam_handle);
 		if (rc) {
-			MSM_HS_ERR("msm_serial_hs: BAM device register failed\n");
+			MSM_HS_ERR("%s: BAM device register failed\n",
+				  __func__);
 			return rc;
 		}
-		MSM_HS_INFO("msm_serial_hs: BAM device registered. bam_handle=0x%x",
-							msm_uport->bam_handle);
+		MSM_HS_DBG("%s:BAM device registered. bam_handle=0x%x",
+			   __func__, msm_uport->bam_handle);
 	}
 	msm_uport->bam_handle = bam_handle;
 
@@ -2851,54 +3154,21 @@ deregister_bam:
 	return rc;
 }
 
+#define BLSP_UART_NR	12
+static int deviceid[BLSP_UART_NR] = {0};
+static atomic_t msm_serial_hs_next_id = ATOMIC_INIT(0);
 
-static bool deviceid[UARTDM_NR] = {0};
-/*
- * The mutex synchronizes grabbing next free device number
- * both in case of an alias being used or not. When alias is
- * used, the msm_hs_dt_to_pdata gets it and the boolean array
- * is accordingly updated with device_id_set_used. If no alias
- * is used, then device_id_grab_next_free sets that array.
- */
-static DEFINE_MUTEX(mutex_next_device_id);
-
-static int device_id_grab_next_free(void)
+static int msm_hs_probe(struct platform_device *pdev)
 {
-	int i;
-	int ret = -ENODEV;
-	mutex_lock(&mutex_next_device_id);
-	for (i = 0; i < UARTDM_NR; i++)
-		if (!deviceid[i]) {
-			ret = i;
-			deviceid[i] = true;
-			break;
-		}
-	mutex_unlock(&mutex_next_device_id);
-	return ret;
-}
-
-static int device_id_set_used(int index)
-{
-	int ret = 0;
-	mutex_lock(&mutex_next_device_id);
-	if (deviceid[index])
-		ret = -ENODEV;
-	else
-		deviceid[index] = true;
-	mutex_unlock(&mutex_next_device_id);
-	return ret;
-}
-
-static int __devinit msm_hs_probe(struct platform_device *pdev)
-{
-	int ret = 0;
+	int ret = 0, alias_num = -1;
 	struct uart_port *uport;
 	struct msm_hs_port *msm_uport;
 	struct resource *core_resource;
 	struct resource *bam_resource;
+	struct resource *resource;
 	int core_irqres, bam_irqres, wakeup_irqres;
 	struct msm_serial_hs_platform_data *pdata = pdev->dev.platform_data;
-	unsigned long data;
+	const struct of_device_id *match;
 
 	if (pdev->dev.of_node) {
 		dev_dbg(&pdev->dev, "device tree enabled\n");
@@ -2906,21 +3176,33 @@ static int __devinit msm_hs_probe(struct platform_device *pdev)
 		if (IS_ERR(pdata))
 			return PTR_ERR(pdata);
 
-		if (pdev->id < 0) {
-			pdev->id = device_id_grab_next_free();
-			if (pdev->id < 0) {
-				dev_err(&pdev->dev,
-					"Error grabbing next free device id");
-				return pdev->id;
-			}
-		} else {
-			ret = device_id_set_used(pdev->id);
-			if (ret < 0) {
-				dev_err(&pdev->dev, "%d alias taken",
-					pdev->id);
-				return ret;
+		if (pdev->id == -1) {
+			pdev->id = atomic_inc_return(&msm_serial_hs_next_id)-1;
+			deviceid[pdev->id] = 1;
+		}
+
+		/* Use alias from device tree if present
+		 * Alias is used as an optional property
+		 */
+		alias_num = of_alias_get_id(pdev->dev.of_node, "uart");
+		if (alias_num >= 0) {
+			/* If alias_num is between 0 and 11, check that it not
+			 * equal to previous incremented pdev-ids. If it is
+			 * equal to previous pdev.ids , fail deviceprobe.
+			 */
+			if (alias_num < BLSP_UART_NR) {
+				if (deviceid[alias_num] == 0) {
+					pdev->id = alias_num;
+				} else {
+					MSM_HS_ERR("alias_num %d used\n",
+						   alias_num);
+					return -EINVAL;
+				}
+			} else {
+				pdev->id = alias_num;
 			}
 		}
+
 		pdev->dev.platform_data = pdata;
 	}
 
@@ -2931,80 +3213,100 @@ static int __devinit msm_hs_probe(struct platform_device *pdev)
 
 	msm_uport = devm_kzalloc(&pdev->dev, sizeof(struct msm_hs_port),
 			GFP_KERNEL);
-	if (!msm_uport) {
-		MSM_HS_ERR("Memory allocation failed\n");
-		return -ENOMEM;
-	}
-
 	msm_uport->uport.type = PORT_UNKNOWN;
 	uport = &msm_uport->uport;
 	uport->dev = &pdev->dev;
+
+	match = of_match_device(msm_hs_match_table, &pdev->dev);
+	if (match)
+		msm_uport->reg_ptr = (unsigned int *)match->data;
+	else if (is_gsbi_uart(msm_uport))
+		msm_uport->reg_ptr = regmap_nonblsp;
 
 	if (pdev->dev.of_node)
 		msm_uport->uart_type = BLSP_HSUART;
 
 	/* Get required resources for BAM HSUART */
-	core_resource = platform_get_resource_byname(pdev,
-				IORESOURCE_MEM, "core_mem");
-	if (!core_resource) {
-		MSM_HS_ERR("Invalid core HSUART Resources.\n");
-		return -ENXIO;
-	}
-	bam_resource = platform_get_resource_byname(pdev,
-				IORESOURCE_MEM, "bam_mem");
-	if (!bam_resource) {
-		MSM_HS_ERR("Invalid BAM HSUART Resources.\n");
-		return -ENXIO;
-	}
-	core_irqres = platform_get_irq_byname(pdev, "core_irq");
-	if (core_irqres < 0) {
-		MSM_HS_ERR("Invalid core irqres Resources.\n");
-		return -ENXIO;
-	}
-	bam_irqres = platform_get_irq_byname(pdev, "bam_irq");
-	if (bam_irqres < 0) {
-		MSM_HS_ERR("Invalid bam irqres Resources.\n");
-		return -ENXIO;
-	}
-	wakeup_irqres = platform_get_irq_byname(pdev, "wakeup_irq");
-	if (wakeup_irqres < 0) {
-		wakeup_irqres = -1;
-		MSM_HS_DBG("Wakeup irq not specified.\n");
-	}
+	if (is_blsp_uart(msm_uport)) {
+		core_resource = platform_get_resource_byname(pdev,
+					IORESOURCE_MEM, "core_mem");
+		if (!core_resource) {
+			MSM_HS_ERR("Invalid core HSUART Resources.\n");
+			return -ENXIO;
+		}
+		bam_resource = platform_get_resource_byname(pdev,
+					IORESOURCE_MEM, "bam_mem");
+		if (!bam_resource) {
+			MSM_HS_ERR("Invalid BAM HSUART Resources.\n");
+			return -ENXIO;
+		}
+		core_irqres = platform_get_irq_byname(pdev, "core_irq");
+		if (core_irqres < 0) {
+			MSM_HS_ERR("Invalid core irqres Resources.\n");
+			return -ENXIO;
+		}
+		bam_irqres = platform_get_irq_byname(pdev, "bam_irq");
+		if (bam_irqres < 0) {
+			MSM_HS_ERR("Invalid bam irqres Resources.\n");
+			return -ENXIO;
+		}
+		wakeup_irqres = platform_get_irq_byname(pdev, "wakeup_irq");
+		if (wakeup_irqres < 0) {
+			wakeup_irqres = -1;
+			MSM_HS_DBG("Wakeup irq not specified.\n");
+		}
 
-	uport->mapbase = core_resource->start;
+		uport->mapbase = core_resource->start;
 
-	uport->membase = ioremap(uport->mapbase,
-				resource_size(core_resource));
-	if (unlikely(!uport->membase)) {
-		MSM_HS_ERR("UART Resource ioremap Failed.\n");
-		return -ENOMEM;
-	}
-	msm_uport->bam_mem = bam_resource->start;
-	msm_uport->bam_base = ioremap(msm_uport->bam_mem,
-				resource_size(bam_resource));
-	if (unlikely(!msm_uport->bam_base)) {
-		MSM_HS_ERR("UART BAM Resource ioremap Failed.\n");
-		iounmap(uport->membase);
-		return -ENOMEM;
-	}
+		uport->membase = ioremap(uport->mapbase,
+					resource_size(core_resource));
+		if (unlikely(!uport->membase)) {
+			MSM_HS_ERR("UART Resource ioremap Failed.\n");
+			return -ENOMEM;
+		}
+		msm_uport->bam_mem = bam_resource->start;
+		msm_uport->bam_base = ioremap(msm_uport->bam_mem,
+					resource_size(bam_resource));
+		if (unlikely(!msm_uport->bam_base)) {
+			MSM_HS_ERR("UART BAM Resource ioremap Failed.\n");
+			iounmap(uport->membase);
+			return -ENOMEM;
+		}
 
-	uport->irq = core_irqres;
-	msm_uport->bam_irq = bam_irqres;
-	pdata->wakeup_irq = wakeup_irqres;
+		uport->irq = core_irqres;
+		msm_uport->bam_irq = bam_irqres;
+		pdata->wakeup_irq = wakeup_irqres;
 
-	msm_uport->bus_scale_table = msm_bus_cl_get_pdata(pdev);
-	if (!msm_uport->bus_scale_table) {
-		MSM_HS_ERR("BLSP UART: Bus scaling is disabled.\n");
+		msm_uport->bus_scale_table = msm_bus_cl_get_pdata(pdev);
+		if (!msm_uport->bus_scale_table) {
+			MSM_HS_ERR("BLSP UART: Bus scaling is disabled.\n");
+		} else {
+			msm_uport->bus_perf_client =
+				msm_bus_scale_register_client
+					(msm_uport->bus_scale_table);
+			if (IS_ERR(&msm_uport->bus_perf_client)) {
+				MSM_HS_ERR("%s():Bus client register failed\n",
+					   __func__);
+				ret = -EINVAL;
+				goto unmap_memory;
+			}
+		}
 	} else {
-		msm_uport->bus_perf_client =
-			msm_bus_scale_register_client
-				(msm_uport->bus_scale_table);
-		if (IS_ERR(&msm_uport->bus_perf_client)) {
-			MSM_HS_ERR("%s():Bus client register failed\n",
-				   __func__);
-			ret = -EINVAL;
-			goto unmap_memory;
+
+		resource = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+		if (unlikely(!resource))
+			return -ENXIO;
+		uport->mapbase = resource->start;
+		uport->membase = ioremap(uport->mapbase,
+					resource_size(resource));
+		if (unlikely(!uport->membase))
+			return -ENOMEM;
+
+		uport->irq = platform_get_irq(pdev, 0);
+		if (unlikely((int)uport->irq < 0)) {
+			MSM_HS_ERR("UART IRQ Failed.\n");
+			iounmap(uport->membase);
+			return -ENXIO;
 		}
 	}
 
@@ -3016,10 +3318,35 @@ static int __devinit msm_hs_probe(struct platform_device *pdev)
 		msm_uport->wakeup.inject_rx = pdata->inject_rx_on_wakeup;
 		msm_uport->wakeup.rx_to_inject = pdata->rx_to_inject;
 
-		msm_uport->bam_tx_ep_pipe_index =
-				pdata->bam_tx_ep_pipe_index;
-		msm_uport->bam_rx_ep_pipe_index =
-				pdata->bam_rx_ep_pipe_index;
+		if (is_blsp_uart(msm_uport)) {
+			msm_uport->bam_tx_ep_pipe_index =
+					pdata->bam_tx_ep_pipe_index;
+			msm_uport->bam_rx_ep_pipe_index =
+					pdata->bam_rx_ep_pipe_index;
+		}
+	}
+
+	if (!is_blsp_uart(msm_uport)) {
+
+		resource = platform_get_resource_byname(pdev,
+					IORESOURCE_DMA, "uartdm_channels");
+		if (unlikely(!resource)) {
+			ret =  -ENXIO;
+			goto deregister_bus_client;
+		}
+
+		msm_uport->dma_tx_channel = resource->start;
+		msm_uport->dma_rx_channel = resource->end;
+
+		resource = platform_get_resource_byname(pdev,
+					IORESOURCE_DMA, "uartdm_crci");
+		if (unlikely(!resource)) {
+			ret = -ENXIO;
+			goto deregister_bus_client;
+		}
+
+		msm_uport->dma_tx_crci = resource->start;
+		msm_uport->dma_rx_crci = resource->end;
 	}
 
 	uport->iotype = UPIO_MEM;
@@ -3068,13 +3395,20 @@ static int __devinit msm_hs_probe(struct platform_device *pdev)
 
 
 	/* Initialize SPS HW connected with UART core */
-	ret = msm_hs_sps_init(msm_uport);
-	if (unlikely(ret)) {
-		MSM_HS_ERR("SPS Initialization failed ! err=%d", ret);
-		goto destroy_mutex;
+	if (is_blsp_uart(msm_uport)) {
+		ret = msm_hs_sps_init(msm_uport);
+		if (unlikely(ret)) {
+			MSM_HS_ERR("SPS Initialization failed ! err=%d", ret);
+			goto destroy_mutex;
+		}
 	}
 
-	msm_hs_clock_vote(msm_uport);
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		goto destroy_mutex;
+	}
 
 	ret = uartdm_init_port(uport);
 	if (unlikely(ret)) {
@@ -3091,27 +3425,15 @@ static int __devinit msm_hs_probe(struct platform_device *pdev)
 	 */
 	mb();
 
-	/*
-	* Set RX_BREAK_ZERO_CHAR_OFF and RX_ERROR_CHAR_OFF
-	* so any rx_break and character having parity of framing
-	* error don't enter inside UART RX FIFO.
-	*/
-	data = msm_hs_read(uport, UART_DM_MR2);
-	data |= (UARTDM_MR2_RX_BREAK_ZERO_CHAR_OFF |
-			UARTDM_MR2_RX_ERROR_CHAR_OFF);
-	msm_hs_write(uport, UART_DM_MR2, data);
-	mb();
-
+	msm_uport->clk_state = MSM_HS_CLK_PORT_OFF;
 	hrtimer_init(&msm_uport->clk_off_timer, CLOCK_MONOTONIC,
 		     HRTIMER_MODE_REL);
 	msm_uport->clk_off_timer.function = msm_hs_clk_off_retry;
 	msm_uport->clk_off_delay = ktime_set(0, 1000000);  /* 1ms */
 
 	ret = sysfs_create_file(&pdev->dev.kobj, &dev_attr_clock.attr);
-	if (unlikely(ret)) {
-		MSM_HS_ERR("Probe Failed as sysfs failed\n");
+	if (unlikely(ret))
 		goto err_clock;
-	}
 
 	msm_serial_debugfs_init(msm_uport, pdev->id);
 
@@ -3121,7 +3443,6 @@ static int __devinit msm_hs_probe(struct platform_device *pdev)
 	ret = uart_add_one_port(&msm_hs_driver, uport);
 	if (!ret) {
 		msm_hs_clock_unvote(msm_uport);
-		msm_uport->clk_state = MSM_HS_CLK_PORT_OFF;
 		return ret;
 	}
 
@@ -3140,10 +3461,12 @@ put_clk:
 		clk_put(msm_uport->clk);
 
 deregister_bus_client:
-	msm_bus_scale_unregister_client(msm_uport->bus_perf_client);
+	if (is_blsp_uart(msm_uport))
+		msm_bus_scale_unregister_client(msm_uport->bus_perf_client);
 unmap_memory:
 	iounmap(uport->membase);
-	iounmap(msm_uport->bam_base);
+	if (is_blsp_uart(msm_uport))
+		iounmap(msm_uport->bam_base);
 
 	return ret;
 }
@@ -3153,22 +3476,22 @@ static int __init msm_serial_hs_init(void)
 	int ret;
 
 	ipc_msm_hs_log_ctxt = ipc_log_context_create(IPC_MSM_HS_LOG_PAGES,
-							"msm_serial_hs", 0);
+							"msm_serial_hs");
 	if (!ipc_msm_hs_log_ctxt)
 		MSM_HS_WARN("%s: error creating logging context", __func__);
 
 	ret = uart_register_driver(&msm_hs_driver);
 	if (unlikely(ret)) {
-		MSM_HS_WARN("%s failed to load\n", __func__);
+		MSM_HS_ERR("%s failed to load\n", __func__);
 		return ret;
 	}
 	debug_base = debugfs_create_dir("msm_serial_hs", NULL);
 	if (IS_ERR_OR_NULL(debug_base))
-		MSM_HS_INFO("msm_serial_hs: Cannot create debugfs dir\n");
+		pr_info("msm_serial_hs: Cannot create debugfs dir\n");
 
 	ret = platform_driver_register(&msm_serial_hs_platform_driver);
 	if (ret) {
-		MSM_HS_ERR("%s failed to load\n", __FUNCTION__);
+		MSM_HS_ERR("%s failed to load\n", __func__);
 		debugfs_remove_recursive(debug_base);
 		uart_unregister_driver(&msm_hs_driver);
 		return ret;
@@ -3186,55 +3509,61 @@ static int __init msm_serial_hs_init(void)
 static void msm_hs_shutdown(struct uart_port *uport)
 {
 	int ret;
+	unsigned int data;
+	unsigned long flags;
 	struct msm_hs_port *msm_uport = UARTDM_TO_MSM(uport);
-	struct circ_buf *tx_buf = &uport->state->xmit;
+	struct platform_device *pdev = to_platform_device(uport->dev);
+	const struct msm_serial_hs_platform_data *pdata =
+				pdev->dev.platform_data;
 	struct msm_hs_tx *tx = &msm_uport->tx;
 	struct sps_pipe *sps_pipe_handle = tx->cons.pipe_handle;
-	struct platform_device *pdev = to_platform_device(uport->dev);
 
-	if (pdev->id == 0)
-		printk(KERN_INFO "(msm_serial_hs) msm_hs_shutdown\n");
-
-	/*
-	 * cancel the hrtimer first so that
-	 * clk_state can not change in flight
-	 */
-	hrtimer_cancel(&msm_uport->clk_off_timer);
-	flush_work(&msm_uport->clock_off_w);
-
-	if (use_low_power_wakeup(msm_uport))
-		irq_set_irq_wake(msm_uport->wakeup.irq, 0);
-
-	/* wake irq or uart irq is active depending on clk_state */
-	if (msm_uport->clk_state == MSM_HS_CLK_OFF) {
-		if (use_low_power_wakeup(msm_uport))
-			disable_irq(msm_uport->wakeup.irq);
-	} else {
-		disable_irq(uport->irq);
-		wake_unlock(&msm_uport->dma_wake_lock);
+	ret = msm_hs_clock_vote(msm_uport);
+	if (ret) {
+		MSM_HS_ERR("%s(): Error could not turn on UART clk\n",
+				__func__);
+		return;
 	}
 
-	/* make sure tx tasklet finishes */
+	if (msm_uport->tx.dma_in_flight) {
+		if (!is_blsp_uart(msm_uport)) {
+			spin_lock_irqsave(&uport->lock, flags);
+			/* disable UART TX interface to DM */
+			data = msm_hs_read(uport, UART_DM_DMEN);
+			data &= ~UARTDM_TX_DM_EN_BMSK;
+			msm_hs_write(uport, UART_DM_DMEN, data);
+			/* turn OFF UART Transmitter */
+			msm_hs_write(uport, UART_DM_CR,
+				UARTDM_CR_TX_DISABLE_BMSK);
+			/* reset UART TX */
+			msm_hs_write(uport, UART_DM_CR, RESET_TX);
+			/* reset UART TX Error */
+			msm_hs_write(uport, UART_DM_CR, RESET_TX_ERROR);
+			msm_uport->tx.flush = FLUSH_STOP;
+			spin_unlock_irqrestore(&uport->lock, flags);
+			/* discard flush */
+			msm_dmov_flush(msm_uport->dma_tx_channel, 0);
+			ret = wait_event_timeout(msm_uport->tx.wait,
+				msm_uport->tx.flush == FLUSH_SHUTDOWN, 100);
+			if (!ret)
+				MSM_HS_ERR("%s():HSUART TX Stalls.\n",
+					   __func__);
+		} else {
+			/* BAM Disconnect for TX */
+			ret = sps_disconnect(sps_pipe_handle);
+			if (ret)
+				MSM_HS_ERR("%s(): sps_disconnect failed\n",
+							__func__);
+		}
+	}
 	tasklet_kill(&msm_uport->tx.tlet);
-	ret = wait_event_timeout(msm_uport->tx.wait,
-			uart_circ_empty(tx_buf), 500);
-	if (!ret)
-		MSM_HS_WARN("Shutdown called when tx buff not empty");
-
-	/* make sure rx tasklet finishes */
-	tasklet_kill(&msm_uport->rx.tlet);
+	BUG_ON(msm_uport->rx.flush < FLUSH_STOP);
 	wait_event(msm_uport->rx.wait, msm_uport->rx.flush == FLUSH_SHUTDOWN);
+	tasklet_kill(&msm_uport->rx.tlet);
 	cancel_delayed_work_sync(&msm_uport->rx.flip_insert_work);
 	flush_workqueue(msm_uport->hsuart_wq);
+	pm_runtime_disable(uport->dev);
 
-	msm_hs_clock_vote(msm_uport);
-	mutex_lock(&msm_uport->clk_mutex);
-	/* BAM Disconnect for TX */
-	ret = sps_disconnect(sps_pipe_handle);
-	if (ret)
-		MSM_HS_ERR("%s(): sps_disconnect failed\n",
-					__func__);
-	WARN_ON(msm_uport->rx.flush < FLUSH_STOP);
 	/* Disable the transmitter */
 	msm_hs_write(uport, UART_DM_CR, UARTDM_CR_TX_DISABLE_BMSK);
 	/* Disable the receiver */
@@ -3247,27 +3576,33 @@ static void msm_hs_shutdown(struct uart_port *uport)
 	 * Hence mb() requires here.
 	 */
 	mb();
-	mutex_unlock(&msm_uport->clk_mutex);
 
-	msm_uport->rx.buffer_pending = NONE_PENDING;
-	MSM_HS_DBG("%s(): tx, rx events complete", __func__);
 	msm_hs_clock_unvote(msm_uport);
 	if (msm_uport->clk_state != MSM_HS_CLK_OFF) {
 		/* to balance clk_state */
 		msm_hs_clock_unvote(msm_uport);
+		wake_unlock(&msm_uport->dma_wake_lock);
 	}
 
-	pm_runtime_disable(uport->dev);
 	msm_uport->clk_state = MSM_HS_CLK_PORT_OFF;
 	dma_unmap_single(uport->dev, msm_uport->tx.dma_base,
 			 UART_XMIT_SIZE, DMA_TO_DEVICE);
+
+	if (use_low_power_wakeup(msm_uport))
+		irq_set_irq_wake(msm_uport->wakeup.irq, 0);
 
 	/* Free the interrupt */
 	free_irq(uport->irq, msm_uport);
 	if (use_low_power_wakeup(msm_uport))
 		free_irq(msm_uport->wakeup.irq, msm_uport);
 
-	msm_hs_unconfig_uart_gpios(uport);
+	if (is_blsp_uart(msm_uport)) {
+		msm_hs_unconfig_uart_gpios(uport);
+	} else {
+		if (pdata && pdata->gpio_config)
+			if (pdata->gpio_config(0))
+				dev_err(uport->dev, "GPIO config error\n");
+	}
 }
 
 static void __exit msm_serial_hs_exit(void)
@@ -3323,7 +3658,7 @@ static const struct dev_pm_ops msm_hs_dev_pm_ops = {
 
 static struct platform_driver msm_serial_hs_platform_driver = {
 	.probe	= msm_hs_probe,
-	.remove = __devexit_p(msm_hs_remove),
+	.remove = msm_hs_remove,
 	.driver = {
 		.name = "msm_serial_hs",
 		.pm   = &msm_hs_dev_pm_ops,
@@ -3353,7 +3688,9 @@ static struct uart_ops msm_hs_ops = {
 	.set_termios = msm_hs_set_termios,
 	.type = msm_hs_type,
 	.config_port = msm_hs_config_port,
-	.flush_buffer = NULL,
+	.release_port = msm_hs_release_port,
+	.request_port = msm_hs_request_port,
+	.flush_buffer = msm_hs_flush_buffer,
 	.ioctl = msm_hs_ioctl,
 };
 

--- a/drivers/tty/serial/msm_serial_hs_hwreg.h
+++ b/drivers/tty/serial/msm_serial_hs_hwreg.h
@@ -1,6 +1,6 @@
 /* drivers/serial/msm_serial_hs_hwreg.h
  *
- * Copyright (c) 2007-2009, 2012-2014,The Linux Foundation. All rights reserved.
+ * Copyright (c) 2007-2009, 2012-2013,The Linux Foundation. All rights reserved.
  * 
  * All source code in this file is licensed under the following license
  * except where indicated.
@@ -61,27 +61,28 @@ enum msm_hsl_regs {
 };
 
 enum msm_hs_regs {
-	UART_DM_MR1 = 0x0,
-	UART_DM_MR2 = 0x4,
-	UART_DM_IMR = 0xb0,
-	UART_DM_SR = 0xa4,
-	UART_DM_CR = 0xa8,
-	UART_DM_CSR = 0xa0,
-	UART_DM_IPR = 0x18,
-	UART_DM_ISR = 0xb4,
-	UART_DM_RX_TOTAL_SNAP = 0xbc,
-	UART_DM_TFWR = 0x1c,
-	UART_DM_RFWR = 0x20,
-	UART_DM_RF = 0x140,
-	UART_DM_TF = 0x100,
-	UART_DM_MISR = 0xac,
-	UART_DM_DMRX = 0x34,
-	UART_DM_NCF_TX = 0x40,
-	UART_DM_DMEN = 0x3c,
-	UART_DM_TXFS = 0x4c,
-	UART_DM_RXFS = 0x50,
-	UART_DM_RX_TRANS_CTRL = 0xcc,
-	UART_DM_BCR = 0xc8,
+	UART_DM_MR1,
+	UART_DM_MR2,
+	UART_DM_IMR,
+	UART_DM_SR,
+	UART_DM_CR,
+	UART_DM_CSR,
+	UART_DM_IPR,
+	UART_DM_ISR,
+	UART_DM_RX_TOTAL_SNAP,
+	UART_DM_RFWR,
+	UART_DM_TFWR,
+	UART_DM_RF,
+	UART_DM_TF,
+	UART_DM_MISR,
+	UART_DM_DMRX,
+	UART_DM_NCF_TX,
+	UART_DM_DMEN,
+	UART_DM_TXFS,
+	UART_DM_RXFS,
+	UART_DM_RX_TRANS_CTRL,
+	UART_DM_BCR,
+	UART_DM_LAST,
 };
 
 #define UARTDM_MR1_ADDR 0x0

--- a/drivers/tty/serial/msm_serial_hs_lite.c
+++ b/drivers/tty/serial/msm_serial_hs_lite.c
@@ -2,7 +2,7 @@
  * drivers/serial/msm_serial.c - driver for msm7k serial device and console
  *
  * Copyright (C) 2007 Google, Inc.
- * Copyright (c) 2010-2013, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2010-2014, The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -49,10 +49,8 @@
 #include <linux/wakelock.h>
 #include <linux/types.h>
 #include <asm/byteorder.h>
-#include <mach/board.h>
-#include <mach/msm_serial_hs_lite.h>
-#include <mach/msm_bus.h>
-#include <asm/mach-types.h>
+#include <linux/platform_data/qcom-serial_hs_lite.h>
+#include <linux/msm-bus.h>
 #include "msm_serial_hs_hwreg.h"
 
 /*
@@ -65,22 +63,6 @@ enum uart_core_type {
 	GSBI_HSUART,
 	BLSP_HSUART,
 };
-
-#if defined(CONFIG_MACH_HLTEDCM)|| defined(CONFIG_MACH_HLTEKDI)
-#define CONFIG_DUMP_UART_PACKET_DISABLE 1
-#endif
-
-#if defined(CONFIG_DUMP_UART_PACKET_DISABLE)
-#define DUMP_UART_PACKET 0
-#else
-#define DUMP_UART_PACKET 1
-#endif
-#define FULL_DUMP_UART_PACKET 0
-
-#if DUMP_UART_PACKET
-static char rx_buf[64]; /* 64 is rx fifo size */
-static char tx_buf[64]; /* 64 is tx fifo size */
-#endif
 
 /*
  * UART can be used in 2-wire or 4-wire mode.
@@ -102,7 +84,7 @@ struct msm_hsl_port {
 	unsigned int            *gsbi_mapbase;
 	unsigned int            *mapped_gsbi;
 	unsigned int            old_snap_state;
-	unsigned int		ver_id;
+	unsigned long		ver_id;
 	int			tx_timeout;
 	struct mutex		clk_mutex;
 	enum uart_core_type	uart_type;
@@ -185,13 +167,13 @@ static inline void msm_hsl_write(struct uart_port *port,
 				 unsigned int val, unsigned int off)
 {
 	__iowmb();
-	__raw_writel_no_log((__force __u32)cpu_to_le32(val),
+	__raw_writel((__force __u32)cpu_to_le32(val),
 		port->membase + off);
 }
 static inline unsigned int msm_hsl_read(struct uart_port *port,
 		     unsigned int off)
 {
-	unsigned int v = le32_to_cpu((__force __le32)__raw_readl_no_log(
+	unsigned int v = le32_to_cpu((__force __le32)__raw_readl(
 		port->membase + off));
 	__iormb();
 	return v;
@@ -574,11 +556,6 @@ static void handle_rx(struct uart_port *port, unsigned int misr)
 	unsigned int sr;
 	int count = 0;
 	struct msm_hsl_port *msm_hsl_port = UART_TO_MSM(port);
-#if DUMP_UART_PACKET
-	int rx_buf_count = 0;
-
-	memset(rx_buf, 0xFF, 64);
-#endif
 
 	vid = msm_hsl_port->ver_id;
 	/*
@@ -631,41 +608,12 @@ static void handle_rx(struct uart_port *port, unsigned int misr)
 		else if (sr & UARTDM_SR_PAR_FRAME_BMSK)
 			flag = TTY_FRAME;
 
-#if DUMP_UART_PACKET
-		if (count < 4) {
-			if (rx_buf_count <= (sizeof(rx_buf) - count)) {
-				memcpy(rx_buf+rx_buf_count, &c, count);
-				rx_buf_count += count;
-			}
-		} else {
-			if (rx_buf_count <= (sizeof(rx_buf) - sizeof(int))) {
-				memcpy(rx_buf+rx_buf_count, &c, sizeof(int));
-				rx_buf_count += sizeof(int);
-			}
-		}
-#endif
-
 		/* TODO: handle sysrq */
 		/* if (!uart_handle_sysrq_char(port, c)) */
 		tty_insert_flip_string(tty, (char *) &c,
 				       (count > 4) ? 4 : count);
 		count -= 4;
 	}
-#if DUMP_UART_PACKET
-	/* skip insignificanty packet */
-#if FULL_DUMP_UART_PACKET
-	print_hex_dump(KERN_DEBUG, "RX UART: ",
-					16, 1, DUMP_PREFIX_ADDRESS,
-					rx_buf, rx_buf_count, 1);
-#else
-	if (rx_buf_count > 4) {
-		if (!is_console(port))
-			print_hex_dump(KERN_DEBUG, "RX UART: ", 16,
-				1, DUMP_PREFIX_ADDRESS, rx_buf,
-				rx_buf_count > 16 ? 16 : rx_buf_count, 1);
-	}
-#endif
-#endif
 
 	tty_flip_buffer_push(tty);
 }
@@ -679,11 +627,6 @@ static void handle_tx(struct uart_port *port)
 	unsigned int tf_pointer = 0;
 	unsigned int vid;
 
-#if DUMP_UART_PACKET
-	int tx_buf_count = 0;
-
-	memset(tx_buf, 0xFF, 64);
-#endif
 	vid = UART_TO_MSM(port)->ver_id;
 	tx_count = uart_circ_chars_pending(xmit);
 
@@ -739,21 +682,6 @@ static void handle_tx(struct uart_port *port)
 			break;
 		}
 		}
-
-#if DUMP_UART_PACKET
-		if ((tx_count - tf_pointer) < 4) {
-			if (tx_buf_count <= (sizeof(tx_buf) - (tx_count - tf_pointer))) {
-				memcpy(tx_buf+tx_buf_count, &x, tx_count - tf_pointer);
-				tx_buf_count += (tx_count - tf_pointer);
-			}
-		} else {
-			if (tx_buf_count <= (sizeof(tx_buf) - sizeof(int))) {
-				memcpy(tx_buf+tx_buf_count, &x, sizeof(int));
-				tx_buf_count += sizeof(int);
-			}
-		}
-#endif
-
 		msm_hsl_write(port, x, regmap[vid][UARTDM_TF]);
 		xmit->tail = ((tx_count - tf_pointer < 4) ?
 			      (tx_count - tf_pointer + xmit->tail) :
@@ -762,21 +690,6 @@ static void handle_tx(struct uart_port *port)
 		sent_tx = 1;
 	}
 
-#if DUMP_UART_PACKET
-	/* skip echo packet */
-#if FULL_DUMP_UART_PACKET
-	print_hex_dump(KERN_DEBUG, "TX UART: ",
-				16, 1, DUMP_PREFIX_ADDRESS,
-				tx_buf, tx_count, 1);
-#else
-	if (tx_count > 4) {
-		if (!is_console(port))
-			print_hex_dump(KERN_DEBUG, "TX UART: ",
-				16, 1, DUMP_PREFIX_ADDRESS,
-				tx_buf, tx_count > 16 ? 16 : tx_count, 1);
-	}
-#endif
-#endif
 	if (uart_circ_empty(xmit))
 		msm_hsl_stop_tx(port);
 
@@ -1481,7 +1394,7 @@ static void dump_hsl_regs(struct uart_port *port)
 /*
  *  Wait for transmitter & holding register to empty
  *  Derived from wait_for_xmitr in 8250 serial driver by Russell King  */
-static void wait_for_xmitr(struct uart_port *port)
+static inline void wait_for_xmitr(struct uart_port *port)
 {
 	struct msm_hsl_port *msm_hsl_port = UART_TO_MSM(port);
 	unsigned int vid = msm_hsl_port->ver_id;
@@ -1497,8 +1410,13 @@ static void wait_for_xmitr(struct uart_port *port)
 			touch_nmi_watchdog();
 			cpu_relax();
 			if (++count == msm_hsl_port->tx_timeout) {
+				pr_info("%s: UART TX Stuck, Resetting TX\n",
+								 __func__);
+				msm_hsl_write(port, RESET_TX,
+					regmap[vid][UARTDM_CR]);
+				mb();
 				dump_hsl_regs(port);
-				panic("MSM HSL wait_for_xmitr is stuck!");
+				break;
 			}
 		}
 		msm_hsl_write(port, CLEAR_TX_READY, regmap[vid][UARTDM_CR]);
@@ -1771,7 +1689,7 @@ static struct msm_serial_hslite_platform_data
 
 static atomic_t msm_serial_hsl_next_id = ATOMIC_INIT(0);
 
-static int __devinit msm_serial_hsl_probe(struct platform_device *pdev)
+static int msm_serial_hsl_probe(struct platform_device *pdev)
 {
 	struct msm_hsl_port *msm_hsl_port;
 	struct resource *uart_resource;
@@ -1850,7 +1768,7 @@ static int __devinit msm_serial_hsl_probe(struct platform_device *pdev)
 	if (!match) {
 		msm_hsl_port->ver_id = UARTDM_VERSION_11_13;
 	} else {
-		msm_hsl_port->ver_id = (unsigned int)match->data;
+		msm_hsl_port->ver_id = (unsigned long)match->data;
 		/*
 		 * BLSP based UART configuration is available with
 		 * UARTDM v14 Revision. Hence set uart_type as UART_BLSP.
@@ -1929,7 +1847,7 @@ err:
 	return ret;
 }
 
-static int __devexit msm_serial_hsl_remove(struct platform_device *pdev)
+static int msm_serial_hsl_remove(struct platform_device *pdev)
 {
 	struct msm_hsl_port *msm_hsl_port = platform_get_drvdata(pdev);
 	const struct msm_serial_hslite_platform_data *pdata =
@@ -2032,7 +1950,7 @@ static struct dev_pm_ops msm_hsl_dev_pm_ops = {
 
 static struct platform_driver msm_hsl_platform_driver = {
 	.probe = msm_serial_hsl_probe,
-	.remove = __devexit_p(msm_serial_hsl_remove),
+	.remove = msm_serial_hsl_remove,
 	.driver = {
 		.name = "msm_serial_hsl",
 		.owner = THIS_MODULE,

--- a/include/linux/ipc_logging.h
+++ b/include/linux/ipc_logging.h
@@ -10,8 +10,8 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _MSM_IPC_LOGGING_H
-#define _MSM_IPC_LOGGING_H
+#ifndef _IPC_LOGGING_H
+#define _IPC_LOGGING_H
 
 #include <linux/types.h>
 
@@ -41,7 +41,7 @@ struct decode_context {
 	int size;               /* size of output buffer */
 };
 
-#if defined(CONFIG_MSM_IPC_LOGGING)
+#if defined(CONFIG_IPC_LOGGING)
 /*
  * ipc_log_context_create: Create a debug log context
  *                         Should not be called from atomic context

--- a/include/linux/msm-bus.h
+++ b/include/linux/msm-bus.h
@@ -1,0 +1,139 @@
+/* Copyright (c) 2010-2014, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _ARCH_ARM_MACH_MSM_BUS_H
+#define _ARCH_ARM_MACH_MSM_BUS_H
+
+#include <linux/types.h>
+#include <linux/input.h>
+#include <linux/platform_device.h>
+
+/*
+ * Macros for clients to convert their data to ib and ab
+ * Ws : Time window over which to transfer the data in SECONDS
+ * Bs : Size of the data block in bytes
+ * Per : Recurrence period
+ * Tb : Throughput bandwidth to prevent stalling
+ * R  : Ratio of actual bandwidth used to Tb
+ * Ib : Instantaneous bandwidth
+ * Ab : Arbitrated bandwidth
+ *
+ * IB_RECURRBLOCK and AB_RECURRBLOCK:
+ * These are used if the requirement is to transfer a
+ * recurring block of data over a known time window.
+ *
+ * IB_THROUGHPUTBW and AB_THROUGHPUTBW:
+ * These are used for CPU style masters. Here the requirement
+ * is to have minimum throughput bandwidth available to avoid
+ * stalling.
+ */
+#define IB_RECURRBLOCK(Ws, Bs) ((Ws) == 0 ? 0 : ((Bs)/(Ws)))
+#define AB_RECURRBLOCK(Ws, Per) ((Ws) == 0 ? 0 : ((Bs)/(Per)))
+#define IB_THROUGHPUTBW(Tb) (Tb)
+#define AB_THROUGHPUTBW(Tb, R) ((Tb) * (R))
+
+struct msm_bus_vectors {
+	int src; /* Master */
+	int dst; /* Slave */
+	uint64_t ab; /* Arbitrated bandwidth */
+	uint64_t ib; /* Instantaneous bandwidth */
+};
+
+struct msm_bus_paths {
+	int num_paths;
+	struct msm_bus_vectors *vectors;
+};
+
+struct msm_bus_scale_pdata {
+	struct msm_bus_paths *usecase;
+	int num_usecases;
+	const char *name;
+	/*
+	 * If the active_only flag is set to 1, the BW request is applied
+	 * only when at least one CPU is active (powered on). If the flag
+	 * is set to 0, then the BW request is always applied irrespective
+	 * of the CPU state.
+	 */
+	unsigned int active_only;
+};
+
+/* Scaling APIs */
+
+/*
+ * This function returns a handle to the client. This should be used to
+ * call msm_bus_scale_client_update_request.
+ * The function returns 0 if bus driver is unable to register a client
+ */
+
+#if (defined(CONFIG_MSM_BUS_SCALING) || defined(CONFIG_BUS_TOPOLOGY_ADHOC))
+int __init msm_bus_fabric_init_driver(void);
+uint32_t msm_bus_scale_register_client(struct msm_bus_scale_pdata *pdata);
+int msm_bus_scale_client_update_request(uint32_t cl, unsigned int index);
+void msm_bus_scale_unregister_client(uint32_t cl);
+/* AXI Port configuration APIs */
+int msm_bus_axi_porthalt(int master_port);
+int msm_bus_axi_portunhalt(int master_port);
+
+#else
+static inline int __init msm_bus_fabric_init_driver(void) { return 0; }
+
+static inline uint32_t
+msm_bus_scale_register_client(struct msm_bus_scale_pdata *pdata)
+{
+	return 1;
+}
+
+static inline int
+msm_bus_scale_client_update_request(uint32_t cl, unsigned int index)
+{
+	return 0;
+}
+
+static inline void
+msm_bus_scale_unregister_client(uint32_t cl)
+{
+}
+
+static inline int msm_bus_axi_porthalt(int master_port)
+{
+	return 0;
+}
+
+static inline int msm_bus_axi_portunhalt(int master_port)
+{
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_OF) && defined(CONFIG_MSM_BUS_SCALING)
+struct msm_bus_scale_pdata *msm_bus_pdata_from_node(
+		struct platform_device *pdev, struct device_node *of_node);
+struct msm_bus_scale_pdata *msm_bus_cl_get_pdata(struct platform_device *pdev);
+void msm_bus_cl_clear_pdata(struct msm_bus_scale_pdata *pdata);
+#else
+static inline struct msm_bus_scale_pdata
+*msm_bus_cl_get_pdata(struct platform_device *pdev)
+{
+	return NULL;
+}
+
+static inline struct msm_bus_scale_pdata *msm_bus_pdata_from_node(
+		struct platform_device *pdev, struct device_node *of_node)
+{
+	return NULL;
+}
+
+static inline void msm_bus_cl_clear_pdata(struct msm_bus_scale_pdata *pdata)
+{
+}
+#endif
+#endif /*_ARCH_ARM_MACH_MSM_BUS_H*/

--- a/include/linux/msm-sps.h
+++ b/include/linux/msm-sps.h
@@ -1,0 +1,1498 @@
+/* Copyright (c) 2011-2014, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/* Smart-Peripheral-Switch (SPS) API. */
+
+#ifndef _SPS_H_
+#define _SPS_H_
+
+#include <linux/types.h>	/* u32 */
+
+#if defined(CONFIG_PHYS_ADDR_T_64BIT) || defined(CONFIG_ARM_LPAE)
+
+/* Returns upper 4bits of 36bits physical address */
+#define SPS_GET_UPPER_ADDR(addr) ((addr & 0xF00000000ULL) >> 32)
+
+/* Returns 36bits physical address from 32bit address &
+ * flags word */
+#define DESC_FULL_ADDR(flags, addr) (((flags & 0xF) << 32) | addr)
+
+/* Returns flags word with flags and 4bit upper address
+ * from flags and 36bit physical address */
+#define DESC_FLAG_WORD(flags, addr) (((addr & 0xF00000000ULL) >> 32) | flags)
+
+#else
+
+#define SPS_GET_UPPER_ADDR(addr) (0)
+#define DESC_FULL_ADDR(flags, addr) (addr)
+#define DESC_FLAG_WORD(flags, addr) (flags)
+
+#endif
+
+/* Returns upper 4bits of 36bits physical address from
+ * flags word */
+#define DESC_UPPER_ADDR(flags) ((flags & 0xF))
+
+/* Returns lower 32bits of 36bits physical address */
+#define SPS_GET_LOWER_ADDR(addr) ((u32)(addr & 0xFFFFFFFF))
+
+/* SPS device handle indicating use of system memory */
+#define SPS_DEV_HANDLE_MEM       (~0x0ul>>1)
+
+/* SPS device handle indicating use of BAM-DMA */
+
+/* SPS device handle invalid value */
+#define SPS_DEV_HANDLE_INVALID   ((unsigned long)0)
+
+/* BAM invalid IRQ value */
+#define SPS_IRQ_INVALID          0
+
+/* Invalid address value */
+#define SPS_ADDR_INVALID      ((unsigned long)0)
+
+/* Invalid peripheral device enumeration class */
+#define SPS_CLASS_INVALID     ((unsigned long)-1)
+
+/*
+ * This value specifies different configurations for an SPS connection.
+ * A non-default value instructs the SPS driver to search for the configuration
+ * in the fixed connection mapping table.
+ */
+#define SPS_CONFIG_DEFAULT       0
+
+/*
+ * This value instructs the SPS driver to use the default BAM-DMA channel
+ * threshold
+ */
+#define SPS_DMA_THRESHOLD_DEFAULT   0
+
+/* Flag bits supported by SPS hardware for struct sps_iovec */
+#define SPS_IOVEC_FLAG_INT  0x8000  /* Generate interrupt */
+#define SPS_IOVEC_FLAG_EOT  0x4000  /* Generate end-of-transfer indication */
+#define SPS_IOVEC_FLAG_EOB  0x2000  /* Generate end-of-block indication */
+#define SPS_IOVEC_FLAG_NWD  0x1000  /* notify when done */
+#define SPS_IOVEC_FLAG_CMD  0x0800  /* command descriptor */
+#define SPS_IOVEC_FLAG_LOCK  0x0400  /* pipe lock */
+#define SPS_IOVEC_FLAG_UNLOCK  0x0200  /* pipe unlock */
+#define SPS_IOVEC_FLAG_IMME 0x0100  /* immediate command descriptor */
+#define SPS_IOVEC_FLAG_NO_SUBMIT 0x0020  /* Do not submit descriptor to HW */
+#define SPS_IOVEC_FLAG_DEFAULT   0x0010  /* Use driver default */
+
+/* Maximum descriptor/iovec size */
+#define SPS_IOVEC_MAX_SIZE   (32 * 1024 - 1)  /* 32K-1 bytes due to HW limit */
+
+/* BAM device options flags */
+
+/*
+ * BAM will be configured and enabled at boot.  Otherwise, BAM will be
+ * configured and enabled when first pipe connect occurs.
+ */
+#define SPS_BAM_OPT_ENABLE_AT_BOOT  1UL
+/* BAM IRQ is disabled */
+#define SPS_BAM_OPT_IRQ_DISABLED    (1UL << 1)
+/* BAM peripheral is a BAM-DMA */
+#define SPS_BAM_OPT_BAMDMA          (1UL << 2)
+/* BAM IRQ is registered for apps wakeup */
+#define SPS_BAM_OPT_IRQ_WAKEUP      (1UL << 3)
+/* Ignore external block pipe reset */
+#define SPS_BAM_NO_EXT_P_RST        (1UL << 4)
+/* Don't enable local clock gating */
+#define SPS_BAM_NO_LOCAL_CLK_GATING (1UL << 5)
+/* Don't enable writeback cancel*/
+#define SPS_BAM_CANCEL_WB           (1UL << 6)
+
+
+/* BAM device management flags */
+
+/* BAM global device control is managed remotely */
+#define SPS_BAM_MGR_DEVICE_REMOTE   1UL
+/* BAM device supports multiple execution environments */
+#define SPS_BAM_MGR_MULTI_EE        (1UL << 1)
+/* BAM pipes are *not* allocated locally */
+#define SPS_BAM_MGR_PIPE_NO_ALLOC   (1UL << 2)
+/* BAM pipes are *not* configured locally */
+#define SPS_BAM_MGR_PIPE_NO_CONFIG  (1UL << 3)
+/* BAM pipes are *not* controlled locally */
+#define SPS_BAM_MGR_PIPE_NO_CTRL    (1UL << 4)
+/* "Globbed" management properties */
+#define SPS_BAM_MGR_NONE            \
+	(SPS_BAM_MGR_DEVICE_REMOTE | SPS_BAM_MGR_PIPE_NO_ALLOC | \
+	 SPS_BAM_MGR_PIPE_NO_CONFIG | SPS_BAM_MGR_PIPE_NO_CTRL)
+#define SPS_BAM_MGR_LOCAL           0
+#define SPS_BAM_MGR_LOCAL_SHARED    SPS_BAM_MGR_MULTI_EE
+#define SPS_BAM_MGR_REMOTE_SHARED   \
+	(SPS_BAM_MGR_DEVICE_REMOTE | SPS_BAM_MGR_MULTI_EE | \
+	 SPS_BAM_MGR_PIPE_NO_ALLOC)
+#define SPS_BAM_MGR_ACCESS_MASK     SPS_BAM_MGR_NONE
+
+/*
+ * BAM security configuration
+ */
+#define SPS_BAM_NUM_EES             4
+#define SPS_BAM_SEC_DO_NOT_CONFIG   0
+#define SPS_BAM_SEC_DO_CONFIG       0x0A434553
+
+/* BAM pipe selection */
+#define SPS_BAM_PIPE(n)             (1UL << (n))
+
+/* This enum specifies the operational mode for an SPS connection */
+enum sps_mode {
+	SPS_MODE_SRC = 0,  /* end point is the source (producer) */
+	SPS_MODE_DEST,	   /* end point is the destination (consumer) */
+};
+
+
+/*
+ * This enum is a set of bit flag options for SPS connection.
+ * The enums should be OR'd together to create the option set
+ * for the SPS connection.
+ */
+enum sps_option {
+	/*
+	 * Options to enable specific SPS hardware interrupts.
+	 * These bit flags are also used to indicate interrupt source
+	 * for the SPS_EVENT_IRQ event.
+	 */
+	SPS_O_DESC_DONE = 0x00000001,  /* Descriptor processed */
+	SPS_O_INACTIVE  = 0x00000002,  /* Inactivity timeout */
+	SPS_O_WAKEUP    = 0x00000004,  /* Peripheral wake up */
+	SPS_O_OUT_OF_DESC = 0x00000008,/* Out of descriptors */
+	SPS_O_ERROR     = 0x00000010,  /* Error */
+	SPS_O_EOT       = 0x00000020,  /* End-of-transfer */
+	SPS_O_RST_ERROR = 0x00000040,  /* Pipe reset unsucessful error */
+	SPS_O_HRESP_ERROR = 0x00000080,/* Errorneous Hresponse by AHB MASTER */
+
+	/* Options to enable hardware features */
+	SPS_O_STREAMING = 0x00010000,  /* Enable streaming mode (no EOT) */
+	/* Use MTI/SETPEND instead of BAM interrupt */
+	SPS_O_IRQ_MTI   = 0x00020000,
+	/* NWD bit written with EOT for BAM2BAM producer pipe */
+	SPS_O_WRITE_NWD   = 0x00040000,
+       /* EOT set after pipe SW offset advanced */
+	SPS_O_LATE_EOT   = 0x00080000,
+
+	/* Options to enable software features */
+	/* Do not disable a pipe during disconnection */
+	SPS_O_NO_DISABLE      = 0x00800000,
+	/* Transfer operation should be polled */
+	SPS_O_POLL      = 0x01000000,
+	/* Disable queuing of transfer events for the connection end point */
+	SPS_O_NO_Q      = 0x02000000,
+	SPS_O_FLOWOFF   = 0x04000000,  /* Graceful halt */
+	/* SPS_O_WAKEUP will be disabled after triggered */
+	SPS_O_WAKEUP_IS_ONESHOT = 0x08000000,
+	/**
+	 * Client must read each descriptor from the FIFO
+	 * using sps_get_iovec()
+	 */
+	SPS_O_ACK_TRANSFERS = 0x10000000,
+	/* Connection is automatically enabled */
+	SPS_O_AUTO_ENABLE = 0x20000000,
+	/* DISABLE endpoint synchronization for config/enable/disable */
+	SPS_O_NO_EP_SYNC = 0x40000000,
+	/* Allow partial polling duing IRQ mode */
+	SPS_O_HYBRID = 0x80000000,
+};
+
+/**
+ * This enum specifies BAM DMA channel priority.  Clients should use
+ * SPS_DMA_PRI_DEFAULT unless a specific priority is required.
+ */
+enum sps_dma_priority {
+	SPS_DMA_PRI_DEFAULT = 0,
+	SPS_DMA_PRI_LOW,
+	SPS_DMA_PRI_MED,
+	SPS_DMA_PRI_HIGH,
+};
+
+/*
+ * This enum specifies the ownership of a connection resource.
+ * Remote or shared ownership is only possible/meaningful on the processor
+ * that controls resource.
+ */
+enum sps_owner {
+	SPS_OWNER_LOCAL = 0x1,	/* Resource is owned by local processor */
+	SPS_OWNER_REMOTE = 0x2,	/* Resource is owned by a satellite processor */
+};
+
+/* This enum indicates the event associated with a client event trigger */
+enum sps_event {
+	SPS_EVENT_INVALID = 0,
+
+	SPS_EVENT_EOT,		/* End-of-transfer */
+	SPS_EVENT_DESC_DONE,	/* Descriptor processed */
+	SPS_EVENT_OUT_OF_DESC,	/* Out of descriptors */
+	SPS_EVENT_WAKEUP,	/* Peripheral wake up */
+	SPS_EVENT_FLOWOFF,	/* Graceful halt (idle) */
+	SPS_EVENT_INACTIVE,	/* Inactivity timeout */
+	SPS_EVENT_ERROR,	/* Error */
+	SPS_EVENT_RST_ERROR,    /* Pipe Reset unsuccessful */
+	SPS_EVENT_HRESP_ERROR,  /* Errorneous Hresponse by AHB Master*/
+	SPS_EVENT_MAX,
+};
+
+/*
+ * This enum specifies the event trigger mode and is an argument for the
+ * sps_register_event() function.
+ */
+enum sps_trigger {
+	/* Trigger with payload for callback */
+	SPS_TRIGGER_CALLBACK = 0,
+	/* Trigger without payload for wait or poll */
+	SPS_TRIGGER_WAIT,
+};
+
+/*
+ * This enum indicates the desired halting mechanism and is an argument for the
+ * sps_flow_off() function
+ */
+enum sps_flow_off {
+	SPS_FLOWOFF_FORCED = 0,	/* Force hardware into halt state */
+	/* Allow hardware to empty pipe before halting */
+	SPS_FLOWOFF_GRACEFUL,
+};
+
+/*
+ * This enum indicates the target memory heap and is an argument for the
+ * sps_mem_alloc() function.
+ */
+enum sps_mem {
+	SPS_MEM_LOCAL = 0,  /* SPS subsystem local (pipe) memory */
+	SPS_MEM_UC,	    /* Microcontroller (ARM7) local memory */
+};
+
+/*
+ * This enum indicates a timer control operation and is an argument for the
+ * sps_timer_ctrl() function.
+ */
+enum sps_timer_op {
+	SPS_TIMER_OP_CONFIG = 0,
+	SPS_TIMER_OP_RESET,
+/*   SPS_TIMER_OP_START,   Not supported by hardware yet */
+/*   SPS_TIMER_OP_STOP,    Not supported by hardware yet */
+	SPS_TIMER_OP_READ,
+};
+
+/*
+ * This enum indicates the inactivity timer operating mode and is an
+ * argument for the sps_timer_ctrl() function.
+ */
+enum sps_timer_mode {
+	SPS_TIMER_MODE_ONESHOT = 0,
+/*   SPS_TIMER_MODE_PERIODIC,    Not supported by hardware yet */
+};
+
+/* This enum indicates the cases when callback the user of BAM */
+enum sps_callback_case {
+	SPS_CALLBACK_BAM_ERROR_IRQ = 1,     /* BAM ERROR IRQ */
+	SPS_CALLBACK_BAM_HRESP_ERR_IRQ,	    /* Erroneous HResponse */
+	SPS_CALLBACK_BAM_TIMER_IRQ,	    /* Inactivity timer */
+};
+
+/*
+ * This enum indicates the command type in a command element
+ */
+enum sps_command_type {
+	SPS_WRITE_COMMAND = 0,
+	SPS_READ_COMMAND,
+};
+
+/**
+ * struct msm_sps_platform_data - SPS Platform specific data.
+ * @bamdma_restricted_pipes - Bitmask of pipes restricted from local use.
+ *
+ */
+struct msm_sps_platform_data {
+	u32 bamdma_restricted_pipes;
+};
+
+/**
+ * This data type corresponds to the native I/O vector (BAM descriptor)
+ * supported by SPS hardware
+ *
+ * @addr - Buffer physical address.
+ * @size - Buffer size in bytes.
+ * @flags -Flag bitmask (see SPS_IOVEC_FLAG_ #defines).
+ *
+ */
+struct sps_iovec {
+	u32 addr;
+	u32 size:16;
+	u32 flags:16;
+};
+
+/**
+ * This data type corresponds to the native Command Element
+ * supported by SPS hardware
+ *
+ * @addr - register address.
+ * @command - command type.
+ * @data - for write command: content to be written into peripheral register.
+ *         for read command: dest addr to write peripheral register value to.
+ * @mask - register mask.
+ * @reserved - for future usage.
+ *
+ */
+struct sps_command_element {
+	u32 addr:24;
+	u32 command:8;
+	u32 data;
+	u32 mask;
+	u32 reserved;
+};
+
+/*
+ * BAM device's security configuation
+ */
+struct sps_bam_pipe_sec_config_props {
+	u32 pipe_mask;
+	u32 vmid;
+};
+
+struct sps_bam_sec_config_props {
+	/* Per-EE configuration - This is a pipe bit mask for each EE */
+	struct sps_bam_pipe_sec_config_props ees[SPS_BAM_NUM_EES];
+};
+
+/**
+ * This struct defines a BAM device. The client must memset() this struct to
+ * zero before writing device information.  A value of zero for uninitialized
+ * values will instruct the SPS driver to use general defaults or
+ * hardware/BIOS supplied values.
+ *
+ *
+ * @options - See SPS_BAM_OPT_* bit flag.
+ * @phys_addr - BAM base physical address (not peripheral address).
+ * @virt_addr - BAM base virtual address.
+ * @virt_size - For virtual mapping.
+ * @irq - IRQ enum for use in ISR vector install.
+ * @num_pipes - number of pipes. Can be read from hardware.
+ * @summing_threshold - BAM event threshold.
+ *
+ * @periph_class - Peripheral device enumeration class.
+ * @periph_dev_id - Peripheral global device ID.
+ * @periph_phys_addr - Peripheral base physical address, for BAM-DMA only.
+ * @periph_virt_addr - Peripheral base virtual address.
+ * @periph_virt_size - Size for virtual mapping.
+ *
+ * @callback - callback function for BAM user.
+ * @user - pointer to user data.
+ *
+ * @event_threshold - Pipe event threshold.
+ * @desc_size - Size (bytes) of descriptor FIFO.
+ * @data_size - Size (bytes) of data FIFO.
+ * @desc_mem_id - Heap ID for default descriptor FIFO allocations.
+ * @data_mem_id - Heap ID for default data FIFO allocations.
+ *
+ * @manage - BAM device management flags (see SPS_BAM_MGR_*).
+ * @restricted_pipes - Bitmask of pipes restricted from local use.
+ * @ee - Local execution environment index.
+ *
+ * @irq_gen_addr - MTI interrupt generation address. This configuration only
+ * applies to BAM rev 1 and 2 hardware. MTIs are only supported on BAMs when
+ * global config is controlled by a remote processor.
+ * NOTE: This address must correspond to the MTI associated with the "irq" IRQ
+ * enum specified above.
+ *
+ * @sec_config - must be set to SPS_BAM_SEC_DO_CONFIG to perform BAM security
+ * configuration.  Only the processor that manages the BAM is allowed to
+ * perform the configuration. The global (top-level) BAM interrupt will be
+ * assigned to the EE of the processor that manages the BAM.
+ *
+ * @p_sec_config_props - BAM device's security configuation
+ *
+ */
+struct sps_bam_props {
+
+	/* BAM device properties. */
+
+	u32 options;
+	phys_addr_t phys_addr;
+	void *virt_addr;
+	u32 virt_size;
+	u32 irq;
+	u32 num_pipes;
+	u32 summing_threshold;
+
+	/* Peripheral device properties */
+
+	u32 periph_class;
+	u32 periph_dev_id;
+	phys_addr_t periph_phys_addr;
+	void *periph_virt_addr;
+	u32 periph_virt_size;
+
+	/* Connection pipe parameter defaults. */
+
+	u32 event_threshold;
+	u32 desc_size;
+	u32 data_size;
+	u32 desc_mem_id;
+	u32 data_mem_id;
+
+	/* Feedback to BAM user */
+	void (*callback)(enum sps_callback_case, void *);
+	void *user;
+
+	/* Security properties */
+
+	u32 manage;
+	u32 restricted_pipes;
+	u32 ee;
+
+	/* BAM MTI interrupt generation */
+
+	u32 irq_gen_addr;
+
+	/* Security configuration properties */
+
+	u32 sec_config;
+	struct sps_bam_sec_config_props *p_sec_config_props;
+
+	/* Logging control */
+
+	bool constrained_logging;
+	u32 logging_number;
+};
+
+/**
+ *  This struct specifies memory buffer properties.
+ *
+ * @base - Buffer virtual address.
+ * @phys_base - Buffer physical address.
+ * @size - Specifies buffer size (or maximum size).
+ * @min_size - If non-zero, specifies buffer minimum size.
+ *
+ */
+struct sps_mem_buffer {
+	void *base;
+	phys_addr_t phys_base;
+	u32 size;
+	u32 min_size;
+};
+
+/**
+ * This struct defines a connection's end point and is used as the argument
+ * for the sps_connect(), sps_get_config(), and sps_set_config() functions.
+ * For system mode pipe, use SPS_DEV_HANDLE_MEM for the end point that
+ * corresponds to system memory.
+ *
+ * The client can force SPS to reserve a specific pipe on a BAM.
+ * If the pipe is in use, the sps_connect/set_config() will fail.
+ *
+ * @source - Source BAM.
+ * @src_pipe_index - BAM pipe index, 0 to 30.
+ * @destination - Destination BAM.
+ * @dest_pipe_index - BAM pipe index, 0 to 30.
+ *
+ * @mode - specifies which end (source or destination) of the connection will
+ * be controlled/referenced by the client.
+ *
+ * @config - This value is for future use and should be set to
+ * SPS_CONFIG_DEFAULT or left as default from sps_get_config().
+ *
+ * @options - OR'd connection end point options (see SPS_O defines).
+ *
+ * WARNING: The memory provided should be physically contiguous and non-cached.
+ * The user can use one of the following:
+ * 1. sps_alloc_mem() - allocated from pipe-memory.
+ * 2. dma_alloc_coherent() - allocate coherent DMA memory.
+ * 3. dma_map_single() - for using memory allocated by kmalloc().
+ *
+ * @desc - Descriptor FIFO.
+ * @data - Data FIFO (BAM-to-BAM mode only).
+ *
+ * @event_thresh - Pipe event threshold or derivative.
+ * @lock_group - The lock group this pipe belongs to.
+ *
+ * @sps_reserved - Reserved word - client must not modify.
+ *
+ */
+struct sps_connect {
+	unsigned long source;
+	u32 src_pipe_index;
+	unsigned long destination;
+	u32 dest_pipe_index;
+
+	enum sps_mode mode;
+
+	u32 config;
+
+	enum sps_option options;
+
+	struct sps_mem_buffer desc;
+	struct sps_mem_buffer data;
+
+	u32 event_thresh;
+
+	u32 lock_group;
+
+	/* SETPEND/MTI interrupt generation parameters */
+
+	u32 irq_gen_addr;
+	u32 irq_gen_data;
+
+	u32 sps_reserved;
+
+};
+
+/**
+ * This struct defines a satellite connection's end point.  The client of the
+ * SPS driver on the satellite processor must call sps_get_config() to
+ * initialize a struct sps_connect, then copy the values from the struct
+ * sps_satellite to the struct sps_connect before making the sps_connect()
+ * call to the satellite SPS driver.
+ *
+ */
+struct sps_satellite {
+	/**
+	 * These values must be copied to either the source or destination
+	 * corresponding values in the connect struct.
+	 */
+	phys_addr_t dev;
+	u32 pipe_index;
+
+	/**
+	 * These values must be copied to the corresponding values in the
+	 * connect struct
+	 */
+	u32 config;
+	enum sps_option options;
+
+};
+
+/**
+ * This struct defines parameters for allocation of a BAM DMA channel. The
+ * client must memset() this struct to zero before writing allocation
+ * information.  A value of zero for uninitialized values will instruct
+ * the SPS driver to use defaults or "don't care".
+ *
+ * @dev - Associated BAM device handle, or SPS_DEV_HANDLE_DMA.
+ *
+ * @src_owner - Source owner processor ID.
+ * @dest_owner - Destination owner processor ID.
+ *
+ */
+struct sps_alloc_dma_chan {
+	unsigned long dev;
+
+	/* BAM DMA channel configuration parameters */
+
+	u32 threshold;
+	enum sps_dma_priority priority;
+
+	/**
+	 * Owner IDs are global host processor identifiers used by the system
+	 * SROT when establishing execution environments.
+	 */
+	u32 src_owner;
+	u32 dest_owner;
+
+};
+
+/**
+ * This struct defines parameters for an allocated BAM DMA channel.
+ *
+ * @dev - BAM DMA device handle.
+ * @dest_pipe_index - Destination/input/write pipe index.
+ * @src_pipe_index - Source/output/read pipe index.
+ *
+ */
+struct sps_dma_chan {
+	unsigned long dev;
+	u32 dest_pipe_index;
+	u32 src_pipe_index;
+};
+
+/**
+ * This struct is an argument passed payload when triggering a callback event
+ * object registered for an SPS connection end point.
+ *
+ * @user - Pointer registered with sps_register_event().
+ *
+ * @event_id - Which event.
+ *
+ * @iovec - The associated I/O vector. If the end point is a system-mode
+ * producer, the size will reflect the actual number of bytes written to the
+ * buffer by the pipe. NOTE: If this I/O vector was part of a set submitted to
+ * sps_transfer(), then the vector array itself will be	updated with all of
+ * the actual counts.
+ *
+ * @user - Pointer registered with the transfer.
+ *
+ */
+struct sps_event_notify {
+	void *user;
+
+	enum sps_event event_id;
+
+	/* Data associated with the event */
+
+	union {
+		/* Data for SPS_EVENT_IRQ */
+		struct {
+			u32 mask;
+		} irq;
+
+		/* Data for SPS_EVENT_EOT or SPS_EVENT_DESC_DONE */
+
+		struct {
+			struct sps_iovec iovec;
+			void *user;
+		} transfer;
+
+		/* Data for SPS_EVENT_ERROR */
+
+		struct {
+			u32 status;
+		} err;
+
+	} data;
+};
+
+/**
+ * This struct defines a event registration parameters and is used as the
+ * argument for the sps_register_event() function.
+ *
+ * @options - Event options that will trigger the event object.
+ * @mode - Event trigger mode.
+ *
+ * @xfer_done - a pointer to a completion object. NULL if not in use.
+ *
+ * @callback - a callback to call on completion. NULL if not in use.
+ *
+ * @user - User pointer that will be provided in event callback data.
+ *
+ */
+struct sps_register_event {
+	enum sps_option options;
+	enum sps_trigger mode;
+	struct completion *xfer_done;
+	void (*callback)(struct sps_event_notify *notify);
+	void *user;
+};
+
+/**
+ * This struct defines a system memory transfer's parameters and is used as the
+ * argument for the sps_transfer() function.
+ *
+ * @iovec_phys - Physical address of I/O vectors buffer.
+ * @iovec - Pointer to I/O vectors buffer.
+ * @iovec_count - Number of I/O vectors.
+ * @user - User pointer passed in callback event.
+ *
+ */
+struct sps_transfer {
+	phys_addr_t iovec_phys;
+	struct sps_iovec *iovec;
+	u32 iovec_count;
+	void *user;
+};
+
+/**
+ * This struct defines a timer control operation parameters and is used as an
+ * argument for the sps_timer_ctrl() function.
+ *
+ * @op - Timer control operation.
+ * @timeout_msec - Inactivity timeout (msec).
+ *
+ */
+struct sps_timer_ctrl {
+	enum sps_timer_op op;
+
+	/**
+	 * The following configuration parameters must be set when the timer
+	 * control operation is SPS_TIMER_OP_CONFIG.
+	 */
+	enum sps_timer_mode mode;
+	u32 timeout_msec;
+};
+
+/**
+ * This struct defines a timer control operation result and is used as an
+ * argument for the sps_timer_ctrl() function.
+ */
+struct sps_timer_result {
+	u32 current_timer;
+};
+
+
+/*----------------------------------------------------------------------------
+ * Functions specific to sps interface
+ * -------------------------------------------------------------------------*/
+struct sps_pipe;	/* Forward declaration */
+
+#ifdef CONFIG_SPS
+/**
+ * Register a BAM device
+ *
+ * This function registers a BAM device with the SPS driver. For each
+ *peripheral that includes a BAM, the peripheral driver must register
+ * the BAM with the SPS driver.
+ *
+ * A requirement is that the peripheral driver must remain attached
+ * to the SPS driver until the BAM is deregistered. Otherwise, the
+ * system may attempt to unload the SPS driver. BAM registrations would
+ * be lost.
+ *
+ * @bam_props - Pointer to struct for BAM device properties.
+ *
+ * @dev_handle - Device handle will be written to this location (output).
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_register_bam_device(const struct sps_bam_props *bam_props,
+			    unsigned long *dev_handle);
+
+/**
+ * Deregister a BAM device
+ *
+ * This function deregisters a BAM device from the SPS driver. The peripheral
+ * driver should deregister a BAM when the peripheral driver is shut down or
+ * when BAM use should be disabled.
+ *
+ * A BAM cannot be deregistered if any of its pipes is in an active connection.
+ *
+ * When all BAMs have been deregistered, the system is free to unload the
+ * SPS driver.
+ *
+ * @dev_handle - BAM device handle.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_deregister_bam_device(unsigned long dev_handle);
+
+/**
+ * Allocate client state context
+ *
+ * This function allocate and initializes a client state context struct.
+ *
+ * @return pointer to client state context
+ *
+ */
+struct sps_pipe *sps_alloc_endpoint(void);
+
+/**
+ * Free client state context
+ *
+ * This function de-initializes and free a client state context struct.
+ *
+ * @ctx - client context for SPS connection end point
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_free_endpoint(struct sps_pipe *h);
+
+/**
+ * Get the configuration parameters for an SPS connection end point
+ *
+ * This function retrieves the configuration parameters for an SPS connection
+ * end point.
+ * This function may be called before the end point is connected (before
+ * sps_connect is called). This allows the client to specify parameters before
+ * the connection is established.
+ *
+ * The client must call this function to fill it's struct sps_connect
+ * struct before modifying values and passing the struct to sps_set_config().
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @config - Pointer to buffer for the end point's configuration parameters.
+ * Must not be NULL.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_get_config(struct sps_pipe *h, struct sps_connect *config);
+
+/**
+ * Allocate memory from the SPS Pipe-Memory.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @mem - memory type - N/A.
+ *
+ * @mem_buffer - Pointer to struct for allocated memory properties.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_alloc_mem(struct sps_pipe *h, enum sps_mem mem,
+		  struct sps_mem_buffer *mem_buffer);
+
+/**
+ * Free memory from the SPS Pipe-Memory.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @mem_buffer - Pointer to struct for allocated memory properties.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_free_mem(struct sps_pipe *h, struct sps_mem_buffer *mem_buffer);
+
+/**
+ * Connect an SPS connection end point
+ *
+ * This function creates a connection between two SPS peripherals or between
+ * an SPS peripheral and the local host processor (via system memory, end
+ *point SPS_DEV_HANDLE_MEM). Establishing the connection includes
+ * initialization of the SPS hardware and allocation of any other connection
+ * resources (buffer memory, etc.).
+ *
+ * This function requires the client to specify both the source and
+ * destination end points of the SPS connection. However, the handle
+ * returned applies only to the end point of the connection that the client
+ * controls. The end point under control must be specified by the
+ * enum sps_mode mode argument, either SPS_MODE_SRC, SPS_MODE_DEST, or
+ * SPS_MODE_CTL. Note that SPS_MODE_CTL is only supported for I/O
+ * accelerator connections, and only a limited set of control operations are
+ * allowed (TBD).
+ *
+ * For a connection involving system memory
+ * (SPS_DEV_HANDLE_MEM), the peripheral end point must be
+ * specified. For example, SPS_MODE_SRC must be specified for a
+ * BAM-to-system connection, since the BAM pipe is the data
+ * producer.
+ *
+ * For a specific peripheral-to-peripheral connection, there may be more than
+ * one required configuration. For example, there might be high-performance
+ * and low-power configurations for a connection between the two peripherals.
+ * The config argument allows the client to specify different configurations,
+ * which may require different system resource allocations and hardware
+ * initialization.
+ *
+ * A client is allowed to create one and only one connection for its
+ * struct sps_pipe. The handle is used to identify the connection end point
+ * in subsequent SPS driver calls. A specific connection source or
+ * destination end point can be associated with one and only one
+ * struct sps_pipe.
+ *
+ * The client must establish an open device handle to the SPS. To do so, the
+ * client must attach to the SPS driver and open the SPS device by calling
+ * the following functions.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @connect - Pointer to connection parameters
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_connect(struct sps_pipe *h, struct sps_connect *connect);
+
+/**
+ * Disconnect an SPS connection end point
+ *
+ * This function disconnects an SPS connection end point.
+ * The SPS hardware associated with that end point will be disabled.
+ * For a connection involving system memory (SPS_DEV_HANDLE_MEM), all
+ * connection resources are deallocated. For a peripheral-to-peripheral
+ * connection, the resources associated with the connection will not be
+ * deallocated until both end points are closed.
+ *
+ * The client must call sps_connect() for the handle before calling
+ * this function.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_disconnect(struct sps_pipe *h);
+
+/**
+ * Register an event object for an SPS connection end point
+ *
+ * This function registers a callback event object for an SPS connection end
+ *point. The registered event object will be triggered for the set of
+ * events specified in reg->options that are enabled for the end point.
+ *
+ * There can only be one registered event object for each event. If an event
+ * object is already registered for an event, it will be replaced. If
+ *reg->event handle is NULL, then any registered event object for the
+ * event will be deregistered. Option bits in reg->options not associated
+ * with events are ignored.
+ *
+ * The client must call sps_connect() for the handle before calling
+ * this function.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @reg - Pointer to event registration parameters
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_register_event(struct sps_pipe *h, struct sps_register_event *reg);
+
+/**
+ * Perform a single DMA transfer on an SPS connection end point
+ *
+ * This function submits a DMA transfer request consisting of a single buffer
+ * for an SPS connection end point associated with a peripheral-to/from-memory
+ * connection. The request will be submitted immediately to hardware if the
+ * hardware is idle (data flow off, no other pending transfers). Otherwise, it
+ * will be queued for later handling in the SPS driver work loop.
+ *
+ * The data buffer must be DMA ready. The client is responsible for insuring
+ *physically contiguous memory, cache maintenance, and memory barrier. For
+ * more information, see Appendix A.
+ *
+ * The client must not modify the data buffer until the completion indication is
+ * received.
+ *
+ * This function cannot be used if transfer queuing is disabled (see option
+ * SPS_O_NO_Q). The client must set the SPS_O_EOT option to receive a callback
+ * event trigger when the transfer is complete. The SPS driver will insure the
+ * appropriate flags in the I/O vectors are set to generate the completion
+ * indication.
+ *
+ * The return value from this function may indicate that an error occurred.
+ * Possible causes include invalid arguments.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @addr - Physical address of buffer to transfer.
+ *
+ * WARNING: The memory provided	should be physically contiguous and
+ * non-cached.
+ *
+ * The user can use one of the following:
+ * 1. sps_alloc_mem() - allocated from pipe-memory.
+ * 2. dma_alloc_coherent() - allocate DMA memory.
+ * 3. dma_map_single() for memory allocated by kmalloc().
+ *
+ * @size - Size in bytes of buffer to transfer
+ *
+ * @user - User pointer that will be returned to user as part of
+ *  event payload
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_transfer_one(struct sps_pipe *h, phys_addr_t addr, u32 size,
+		     void *user, u32 flags);
+
+/**
+ * Read event queue for an SPS connection end point
+ *
+ * This function reads event queue for an SPS connection end point.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @event - pointer to client's event data buffer
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_get_event(struct sps_pipe *h, struct sps_event_notify *event);
+
+/**
+ * Get processed I/O vector (completed transfers)
+ *
+ * This function fetches the next processed I/O vector.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @iovec - Pointer to I/O vector struct (output).
+ * This struct will be zeroed if there are no more processed I/O vectors.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_get_iovec(struct sps_pipe *h, struct sps_iovec *iovec);
+
+/**
+ * Enable an SPS connection end point
+ *
+ * This function enables an SPS connection end point.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_flow_on(struct sps_pipe *h);
+
+/**
+ * Disable an SPS connection end point
+ *
+ * This function disables an SPS connection end point.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @mode - Desired mode for disabling pipe data flow
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_flow_off(struct sps_pipe *h, enum sps_flow_off mode);
+
+/**
+ * Perform a Multiple DMA transfer on an SPS connection end point
+ *
+ * This function submits a DMA transfer request for an SPS connection end point
+ * associated with a peripheral-to/from-memory connection. The request will be
+ * submitted immediately to hardware if the hardware is idle (data flow off, no
+ * other pending transfers). Otherwise, it will be queued for later handling in
+ * the SPS driver work loop.
+ *
+ * The data buffers referenced by the I/O vectors must be DMA ready.
+ * The client is responsible for insuring physically contiguous memory,
+ * any cache maintenance, and memory barrier. For more information,
+ * see Appendix A.
+ *
+ * The I/O vectors must specify physical addresses for the referenced buffers.
+ *
+ * The client must not modify the data buffers referenced by I/O vectors until
+ * the completion indication is received.
+ *
+ * If transfer queuing is disabled (see option SPS_O_NO_Q), the client is
+ * responsible for setting the appropriate flags in the I/O vectors to generate
+ * the completion indication. Also, the client is responsible for enabling the
+ * appropriate connection callback event options for completion indication (see
+ * sps_connect(), sps_set_config()).
+ *
+ * If transfer queuing is enabled, the client must set the SPS_O_EOT option to
+ * receive a callback event trigger when the transfer is complete. The SPS
+ * driver will insure the appropriate flags in the I/O vectors are set to
+ * generate the completion indication. The client must not set any flags in the
+ * I/O vectors, as this may cause the SPS driver to become out of sync with the
+ * hardware.
+ *
+ * The return value from this function may indicate that an error occurred.
+ * Possible causes include invalid arguments. If transfer queuing is disabled,
+ * an error will occur if the pipe is already processing a transfer.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @transfer - Pointer to transfer parameter struct
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_transfer(struct sps_pipe *h, struct sps_transfer *transfer);
+
+/**
+ * Determine whether an SPS connection end point FIFO is empty
+ *
+ * This function returns the empty state of an SPS connection end point.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @empty - pointer to client's empty status word (boolean)
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_is_pipe_empty(struct sps_pipe *h, u32 *empty);
+
+/**
+ * Reset an SPS BAM device
+ *
+ * This function resets an SPS BAM device.
+ *
+ * @dev - device handle for the BAM
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_device_reset(unsigned long dev);
+
+/**
+ * Set the configuration parameters for an SPS connection end point
+ *
+ * This function sets the configuration parameters for an SPS connection
+ * end point. This function may be called before the end point is connected
+ * (before sps_connect is called). This allows the client to specify
+ *parameters before the connection is established. The client is allowed
+ * to pre-allocate resources and override driver defaults.
+ *
+ * The client must call sps_get_config() to fill it's struct sps_connect
+ * struct before modifying values and passing the struct to this function.
+ * Only those parameters that differ from the current configuration will
+ * be processed.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @config - Pointer to the end point's new configuration parameters.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_set_config(struct sps_pipe *h, struct sps_connect *config);
+
+/**
+ * Set ownership of an SPS connection end point
+ *
+ * This function sets the ownership of an SPS connection end point to
+ * either local (default) or non-local. This function is used to
+ * retrieve the struct sps_connect data that must be used by a
+ * satellite processor when calling sps_connect().
+ *
+ * Non-local ownership is only possible/meaningful on the processor
+ * that controls resource allocations (apps processor). Setting ownership
+ * to non-local on a satellite processor will fail.
+ *
+ * Setting ownership from non-local to local will succeed only if the
+ * owning satellite processor has properly brought the end point to
+ * an idle condition.
+ *
+ * This function will succeed if the connection end point is already in
+ * the specified ownership state.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @owner - New ownership of the connection end point
+ *
+ * @connect - Pointer to buffer for satellite processor connect data.
+ *  Can be NULL to avoid retrieving the connect data. Will be ignored
+ *  if the end point ownership is set to local.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_set_owner(struct sps_pipe *h, enum sps_owner owner,
+		  struct sps_satellite *connect);
+
+/**
+ * Allocate a BAM DMA channel
+ *
+ * This function allocates a BAM DMA channel. A "BAM DMA" is a special
+ * DMA peripheral with a BAM front end. The DMA peripheral acts as a conduit
+ * for data to flow into a consumer pipe and then out of a producer pipe.
+ * It's primarily purpose is to serve as a path for interprocessor communication
+ * that allows each processor to control and protect it's own memory space.
+ *
+ * @alloc - Pointer to struct for BAM DMA channel allocation properties.
+ *
+ * @chan - Allocated channel information will be written to this
+ *  location (output).
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_alloc_dma_chan(const struct sps_alloc_dma_chan *alloc,
+		       struct sps_dma_chan *chan);
+
+/**
+ * Free a BAM DMA channel
+ *
+ * This function frees a BAM DMA channel.
+ *
+ * @chan - Pointer to information for channel to free
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_free_dma_chan(struct sps_dma_chan *chan);
+
+/**
+ * Get the BAM handle for BAM-DMA.
+ *
+ * The BAM handle should be use as source/destination in the sps_connect().
+ *
+ * @return handle on success, zero on error
+ *
+ */
+unsigned long sps_dma_get_bam_handle(void);
+
+/**
+ * Free the BAM handle for BAM-DMA.
+ *
+ */
+void sps_dma_free_bam_handle(unsigned long h);
+
+
+/**
+ * Get number of free transfer entries for an SPS connection end point
+ *
+ * This function returns the number of free transfer entries for an
+ * SPS connection end point.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @count - pointer to count status
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_get_free_count(struct sps_pipe *h, u32 *count);
+
+/**
+ * Perform timer control
+ *
+ * This function performs timer control operations.
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @timer_ctrl - Pointer to timer control specification
+ *
+ * @timer_result - Pointer to buffer for timer operation result.
+ *  This argument can be NULL if no result is expected for the operation.
+ *  If non-NULL, the current timer value will always provided.
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_timer_ctrl(struct sps_pipe *h,
+		   struct sps_timer_ctrl *timer_ctrl,
+		   struct sps_timer_result *timer_result);
+
+/**
+ * Find the handle of a BAM device based on the physical address
+ *
+ * This function finds a BAM device in the BAM registration list that
+ * matches the specified physical address, and returns its handle.
+ *
+ * @phys_addr - physical address of the BAM
+ *
+ * @h - device handle of the BAM
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_phy2h(phys_addr_t phys_addr, unsigned long *handle);
+
+/**
+ * Setup desc/data FIFO for bam-to-bam connection
+ *
+ * @mem_buffer - Pointer to struct for allocated memory properties.
+ *
+ * @addr - address of FIFO
+ *
+ * @size - FIFO size
+ *
+ * @use_offset - use address offset instead of absolute address
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_setup_bam2bam_fifo(struct sps_mem_buffer *mem_buffer,
+		  u32 addr, u32 size, int use_offset);
+
+/**
+ * Get the number of unused descriptors in the descriptor FIFO
+ * of a pipe
+ *
+ * @h - client context for SPS connection end point
+ *
+ * @desc_num - number of unused descriptors
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_get_unused_desc_num(struct sps_pipe *h, u32 *desc_num);
+
+/**
+ * Get the debug info of BAM registers and descriptor FIFOs
+ *
+ * @dev - BAM device handle
+ *
+ * @option - debugging option
+ *
+ * @para - parameter used for an option (such as pipe combination)
+ *
+ * @tb_sel - testbus selection
+ *
+ * @desc_sel - selection of descriptors
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_get_bam_debug_info(unsigned long dev, u32 option, u32 para,
+		u32 tb_sel, u32 desc_sel);
+
+/**
+ * Vote for or relinquish BAM DMA clock
+ *
+ * @clk_on - to turn on or turn off the clock
+ *
+ * @return 0 on success, negative value on error
+ *
+ */
+int sps_ctrl_bam_dma_clk(bool clk_on);
+#else
+static inline int sps_register_bam_device(const struct sps_bam_props
+			*bam_props, unsigned long *dev_handle)
+{
+	return -EPERM;
+}
+
+static inline int sps_deregister_bam_device(unsigned long dev_handle)
+{
+	return -EPERM;
+}
+
+static inline struct sps_pipe *sps_alloc_endpoint(void)
+{
+	return NULL;
+}
+
+static inline int sps_free_endpoint(struct sps_pipe *h)
+{
+	return -EPERM;
+}
+
+static inline int sps_get_config(struct sps_pipe *h, struct sps_connect *config)
+{
+	return -EPERM;
+}
+
+static inline int sps_alloc_mem(struct sps_pipe *h, enum sps_mem mem,
+		  struct sps_mem_buffer *mem_buffer)
+{
+	return -EPERM;
+}
+
+static inline int sps_free_mem(struct sps_pipe *h,
+				struct sps_mem_buffer *mem_buffer)
+{
+	return -EPERM;
+}
+
+static inline int sps_connect(struct sps_pipe *h, struct sps_connect *connect)
+{
+	return -EPERM;
+}
+
+static inline int sps_disconnect(struct sps_pipe *h)
+{
+	return -EPERM;
+}
+
+static inline int sps_register_event(struct sps_pipe *h,
+					struct sps_register_event *reg)
+{
+	return -EPERM;
+}
+
+static inline int sps_transfer_one(struct sps_pipe *h, phys_addr_t addr,
+					u32 size, void *user, u32 flags)
+{
+	return -EPERM;
+}
+
+static inline int sps_get_event(struct sps_pipe *h,
+				struct sps_event_notify *event)
+{
+	return -EPERM;
+}
+
+static inline int sps_get_iovec(struct sps_pipe *h, struct sps_iovec *iovec)
+{
+	return -EPERM;
+}
+
+static inline int sps_flow_on(struct sps_pipe *h)
+{
+	return -EPERM;
+}
+
+static inline int sps_flow_off(struct sps_pipe *h, enum sps_flow_off mode)
+{
+	return -EPERM;
+}
+
+static inline int sps_transfer(struct sps_pipe *h,
+				struct sps_transfer *transfer)
+{
+	return -EPERM;
+}
+
+static inline int sps_is_pipe_empty(struct sps_pipe *h, u32 *empty)
+{
+	return -EPERM;
+}
+
+static inline int sps_device_reset(unsigned long dev)
+{
+	return -EPERM;
+}
+
+static inline int sps_set_config(struct sps_pipe *h, struct sps_connect *config)
+{
+	return -EPERM;
+}
+
+static inline int sps_set_owner(struct sps_pipe *h, enum sps_owner owner,
+		  struct sps_satellite *connect)
+{
+	return -EPERM;
+}
+
+static inline int sps_get_free_count(struct sps_pipe *h, u32 *count)
+{
+	return -EPERM;
+}
+
+static inline int sps_alloc_dma_chan(const struct sps_alloc_dma_chan *alloc,
+		       struct sps_dma_chan *chan)
+{
+	return -EPERM;
+}
+
+static inline int sps_free_dma_chan(struct sps_dma_chan *chan)
+{
+	return -EPERM;
+}
+
+static inline unsigned long sps_dma_get_bam_handle(void)
+{
+	return 0;
+}
+
+static inline void sps_dma_free_bam_handle(unsigned long h)
+{
+}
+
+static inline int sps_timer_ctrl(struct sps_pipe *h,
+		   struct sps_timer_ctrl *timer_ctrl,
+		   struct sps_timer_result *timer_result)
+{
+	return -EPERM;
+}
+
+static inline int sps_phy2h(phys_addr_t phys_addr, unsigned long *handle)
+{
+	return -EPERM;
+}
+
+static inline int sps_setup_bam2bam_fifo(struct sps_mem_buffer *mem_buffer,
+		  u32 addr, u32 size, int use_offset)
+{
+	return -EPERM;
+}
+
+static inline int sps_get_unused_desc_num(struct sps_pipe *h, u32 *desc_num)
+{
+	return -EPERM;
+}
+
+static inline int sps_get_bam_debug_info(unsigned long dev, u32 option,
+		u32 para, u32 tb_sel, u32 desc_sel)
+{
+	return -EPERM;
+}
+
+static inline int sps_ctrl_bam_dma_clk(bool clk_on)
+{
+	return -EPERM;
+}
+#endif
+
+#endif /* _SPS_H_ */

--- a/include/linux/platform_data/qcom-serial_hs_lite.h
+++ b/include/linux/platform_data/qcom-serial_hs_lite.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2011-2013 The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef __ASM_ARCH_MSM_SERIAL_HS_LITE_H
+#define __ASM_ARCH_MSM_SERIAL_HS_LITE_H
+/**
+ * struct msm_serial_hslite_platform_data - platform device data
+ *              for msm_hs_lite.
+ * @config_gpio: Select GPIOs to configure.
+ *		Set 4 if 4-wire UART used (for Tx, Rx, CTS, RFR GPIOs).
+ *		Set 1 if 2-wire UART used (for Tx, Rx GPIOs).
+ * @uart_tx_gpio: GPIO number for UART Tx Line.
+ * @uart_rx_gpio: GPIO number for UART Rx Line.
+ * @uart_cts_gpio: GPIO number for UART CTS Line.
+ * @uart_rfr_gpio: GPIO number for UART RFR Line.
+ * @set_uart_clk_zero: use this if setting UART Clock to zero is required
+ * It is mainly required where same UART is used across different processor.
+ * Make sure that Clock driver for platform support setting clock rate to zero.
+ * @use_pm: use this to enable power management
+ * @line: Used to set UART Port number.
+ */
+struct msm_serial_hslite_platform_data {
+	unsigned config_gpio;
+	unsigned uart_tx_gpio;
+	unsigned uart_rx_gpio;
+	unsigned uart_cts_gpio;
+	unsigned uart_rfr_gpio;
+	bool set_uart_clk_zero;
+	bool use_pm;
+	int line;
+};
+
+#endif
+


### PR DESCRIPTION
New Bluetooth drivers from official CyanogenMod 12 by @noobnl
is still causing weird battery drains and A2DP issues,

whereas my sprat Bluetooth port is working perfectly fine.

Let's stick with sprat until @noobnl figures all the stuffs out.

This mass reverts requires userspace(vnd_hlte.txt) changes too.

commit 3f1d09eb0efecc58544eaccf3f4c30c14c7924a2
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:52:25 2015 +0900

```
Revert "Revert "drivers: port bluesleep, msm_serial_hs from android-msm-sprat-3.10-kitkat-wear (experimental)""

This reverts commit 1412eb371bb7963a50fabb522ed8996536b59bbe.
```

commit 4c841a00d4284c2a89a7cb4a8ad5674ff2fea896
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:52:20 2015 +0900

```
Revert "Hlte bluesleep: increase tx time out to 5 second"

This reverts commit 0f77dccaab16100eb194716e1e9a4b4fedf90a71.
```

commit a37f73a205265051976833383f2c1e4e565a06bd
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:52:01 2015 +0900

```
Revert "msm: ipc_logging: add client version support"

This reverts commit a671b18dad317b68ad11f28942c1098b5a84663b.
```

commit 0d1ca9edffa5aab1b2f088b41700cc1a424e1886
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:52:00 2015 +0900

```
Revert "msm_serial_hs:Enable Error/Break Char off"

This reverts commit e840316850281912138e1056eadb53cfd7f10e13.
```

commit f42077d6b1006e14a4bba608ca02164bc7c97168
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:52:00 2015 +0900

```
Revert "msm_serial_hs: Dynamic allocation of port structures"

This reverts commit d930664747fda960262ffed98fb31afde4988438.
```

commit dc2bbb8bd1ca7f71d9829d9024084e0268b9b25a
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:59 2015 +0900

```
Revert "msm_serial_hs: Implement driver functionality to be closer to HW spec"

This reverts commit 45277cdc2885b6716693315d97fde023935e48b7.
```

commit 1f93850106b880a37195773890178c4f8175cb00
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:58 2015 +0900

```
Revert "msm_serial_hs: Defensive checks"

This reverts commit 822e456043de12385e6776a3ab1d3fc06ef4e7bc.
```

commit 4bdc14bd22874e36bd69190428bf19f34066983e
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:58 2015 +0900

```
Revert "msm_serial_hs: Manage clock path-vote correctly"

This reverts commit 060750ad6cba164b086737e829c86b0b2f952a41.
```

commit 90b13a43e056bb9d9480f813ce4c15b293201ad4
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:57 2015 +0900

```
Revert "msm_serial_hs: Avoid RX getting stuck during rapid clock on/off"

This reverts commit 74928c6df07ba4c6ca2c6423d2ba9cd1ccfdb0f9.
```

commit 6eff9cb65ac365d44c7057c463b44890245ac0e3
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:57 2015 +0900

```
Revert "msm_serial_hs: Race Condition during Baud Rate Configuration"

This reverts commit 1c1b5d280a8889ae2da004245748f7ff96877109.
```

commit 764aeed3a5d7c26a9c5d40040f6ab421f299c73b
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:56 2015 +0900

```
Revert "msm_serial_hs: Program RFR to synchronize clock-off sequence with HW"

This reverts commit b6ed29764d09b29a0e713bc340f54a629055913b.
```

commit d502138962e4e838d163dd0ab9ac116c05faa4c2
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:56 2015 +0900

```
Revert "msm_serial_hs: Programing the TX FIFO watermark level to 4"

This reverts commit fa9a81e86345bc561bec908cbdb55fc0239b18ac.
```

commit 06ae1bad7fc2a9e4b7fafa114032134bd9f0d585
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:55 2015 +0900

```
Revert "msm_serial_hs: fix unbalanced clock vote during port close"

This reverts commit 7afb9d17d032ccce90010d1b73539326971d1e5f.
```

commit a0809463faddcf56bff9c58ca1f0fcdfb08a6bd5
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:54 2015 +0900

```
Revert "msm_serial_hs: Remove code dependency on flag tty_flush_receive"

This reverts commit 56c623de4105d2f30687870c3e958d8b7350ba13.
```

commit a2540eb9ee64e43a4f3e75f7205a33a401f86e13
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:54 2015 +0900

```
Revert "msm_serial_hs: Programming BCR Register"

This reverts commit bfb0fadaa63e617155a4dc851f4af26eb456bd63.
```

commit d948970cf6c537a5cb9d2966eeb6531f1d0e07b7
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:53 2015 +0900

```
Revert "msm_serial_hs: Fix the logic for numbering the serial device"

This reverts commit 1037e8934b9ebd316a1a52ec2395a4905126ee72.
```

commit 1a49c067b1234703749c1d90e6b5a24b33f876d8
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:53 2015 +0900

```
Revert "msm_serial_hs: Fix return value handling from platform_get_irq_by_name"

This reverts commit 4564ea9c5c6c37cb8345e7d4137b3ec2b5537c9a.
```

commit 89b87bd63bd9266ab982913f81db73a784e17c94
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:52 2015 +0900

```
Revert "msm_serial_hs: Manage wake unlock delay"

This reverts commit c1f7ed003dacd27dc5fe23cb166a19c62f8bbc16.
```

commit 43f946c2fd98e256643a313c62e28d848addbcc7
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:52 2015 +0900

```
Revert "msm_serial_hs: remove unused code"

This reverts commit bfa6ec4a70b583bd348b0405b513724c68458cc7.
```

commit 06361eb4364869e9bdb78f4fdb62464b38825734
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:51 2015 +0900

```
Revert "msm_serial_hs: Avoid potential unclocked access by clients"

This reverts commit 7bdf7062021ef08464f7e8ac2f683d4b200af1b3.
```

commit 5f73086098baf94db8f310928ec1030171900591
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:51 2015 +0900

```
Revert "msm_serial_hs: Handle client requests without port open"

This reverts commit 1e8444fe7a7a05c1700d672f3bc73a1ec21399b0.
```

commit ffa93ae2146c249dc7f79f8c02d8b677bae05b77
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:50 2015 +0900

```
Revert "Hlte: msm_serial_hs: fix LA.BF.1.1.1_rb1.1 mismerge"

This reverts commit 9606cbcf885457efefb5beb7c23a856333ccbade.
```

commit 77c962b3fb89f9bc020d184dcb52d9d5abfe51f8
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:49 2015 +0900

```
Revert "hlte: partially mimick klte bluesleep. Disable turning off the hostWake gpio"

This reverts commit 8285ea4e69b4477c0995f036241302ef6026f681.
```

commit e2b03dc788b12b2ca21924be164523d2980e096b
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:17 2015 +0900

```
Revert "Hlte: import relevent  bluesleep changes  from g900f sources."

This reverts commit 95f85cb96bafc52ac33f771a9ca3bc438ab9b254.
```

commit cbf54c87044ff4907918b7579cebc96736bc26cb
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:51:13 2015 +0900

```
Revert "hlte: import msm-serial-hs changes from g900f"

This reverts commit 21538279398d5a36920c52935976fd1a13e134cd.
```

commit d2ff370eac7dd8e71d075ceed3ce309532fb43d9
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:50:43 2015 +0900

```
Revert "hlte: reenable hostwake gpio"

This reverts commit 25722099446f7a2e761bb979f14fd249e6ccf231.
```

commit e0e94859d91e5aeab058470fb3588f6b561e971f
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:50:22 2015 +0900

```
Revert "msm-serial-bus: old cruft"

This reverts commit 94d5c43a0533b1f9f520c301fb7cba4dab508bd3.
```

commit a9a34001f3234f0cbfea86d9a4b639bcf99ede1e
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:50:18 2015 +0900

```
Revert "hlte: fix mis merge fail"

This reverts commit ff56f057702d2c31c2a24a6240d34580443b8e3a.
```

commit 5a6badb5e82f6a40fabfbab32cc0513a8bdfd5f1
Author: arter97 qkrwngud825@gmail.com
Date:   Wed Jan 21 23:50:15 2015 +0900

```
Revert "hlte: merge in g900f msm-serial-hs"

This reverts commit d324af6cfe374d51793168b3ecde9d9f7555d8b6.
```
